### PR TITLE
Set *warn-on-reflection* to true globally during dev

### DIFF
--- a/dev/user.clj
+++ b/dev/user.clj
@@ -2,6 +2,8 @@
   (:require [nextjournal.clerk :as clerk]
             [emmy.env]))
 
+(alter-var-root #'*warn-on-reflection* (constantly true))
+
 (comment
   ;; Activate this line to start the clerk server.
   (clerk/serve!


### PR DESCRIPTION
Thanks to @borkdude (https://twitter.com/borkdude/status/1623271427053953024) for the suggestion. Let's see what warnings pop up in the tests and fix them soon.