### PR TITLE
native JS function compilation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 ## [unreleased]
 
+- #107:
+
+  - move CSE to its own namespace to avoid the circular dependency
+    `compile`->`render`->`compile`
+
+  - refactor JS rendering to allow compiler to use it
+
+  - adjust meaning of :native and :source compilation modes now you get
+    what's compatible with your execution environment but you can also
+    ask for a specific language, allowing tests to be bilingual
+
 - #100:
 
   - Implements predicate support for `segment`, `entire-segment` and

--- a/src/emmy/env/sci.cljc
+++ b/src/emmy/env/sci.cljc
@@ -95,6 +95,7 @@
    'emmy.calculus.vector-field          (ns-publics 'emmy.calculus.vector-field)
    'emmy.expression.analyze             (ns-publics 'emmy.expression.analyze)
    'emmy.expression.compile             (ns-publics 'emmy.expression.compile)
+   'emmy.expression.cse                 (ns-publics 'emmy.expression.cse)
    'emmy.expression.render              (ns-publics 'emmy.expression.render)
    'emmy.mechanics.lagrange             (ns-publics 'emmy.mechanics.lagrange)
    'emmy.mechanics.hamilton             (ns-publics 'emmy.mechanics.hamilton)

--- a/src/emmy/expression/compile.cljc
+++ b/src/emmy/expression/compile.cljc
@@ -151,7 +151,7 @@
 ;; Armed with the above compiler optimization we can move on to the actual
 ;; compilation step.
 ;;
-;; This library provides two compilation modes:
+;; This library provides several compilation modes:
 ;;
 ;; - Native compilation via `eval` in Clojure, transpiling in JavaScript
 ;; - interpreted compilation via [SCI](https://github.com/borkdude/sci), the
@@ -161,7 +161,7 @@
 ;; - just asking for :source will provide the source in whichever environment
 ;;   you're using
 ;;
-;; We default :native for performance.
+;; We default to :native for performance.
 
 (def ^{:dynamic true
        :no-doc true}
@@ -197,10 +197,10 @@
   #?(:cljs (set! *mode* mode)
      :clj  (alter-var-root #'*mode* (constantly mode))))
 
-;; Native compilation works on the JVM, and on ClojureScript if you're running
-;; in a self-hosted CLJS environment. Enable this mode by wrapping your call in
+;; Native compilation works on the JVM and in ClojureScript. Enable this mode
+;; by wrapping your call in
 ;;
-;; `(binding [*mode* :native] ,,,)`
+;; (binding [*mode* :native] ,,,)`
 ;;
 ;; ## State Functions
 ;;
@@ -245,7 +245,7 @@
       [state (into [] params)]
       [state])))
 
-;; The following two functions compile state functions in either native or SCI
+;; The following functions compile state functions in either native or SCI
 ;; mode. The primary difference is that native compilation requires us to
 ;; explicitly replace all instances of symbols from `compiled-fn-whitelist`
 ;; above with actual functions.

--- a/src/emmy/expression/compile.cljc
+++ b/src/emmy/expression/compile.cljc
@@ -302,24 +302,22 @@
 (defn- compile->clj
   "Returns Clojure source for a function that implements `body`, given:
 
-  - `params`: a seq of symbols equal in count to the original state function's
-    args
-  - `state-model`: a sequence of variables representing the structure of the
-    nested function returned by the state function
-  - `body`: a function body making use of any symbol in the args above"
+  - `argv`: a vector of symbols to serve as the function's arguments.
+    The vector may be nested for sequence destructuring.
+
+  - `body`: a function body making use of any symbol in argv above"
   [argv body]
   (let [body (w/postwalk-replace sym->resolved-form body)]
     `(fn [~@argv] ~body)))
 
 (defn- compile->js
   "Returns an array containing JavaScript source for a function that implements
-  `body` in a form suitable for the arguments of the Function constructor, given:
+  `body` in a form suitable for application of the Function constructor, given:
 
-  - `params`: a seq of symbols equal in count to the original state function's
-    args
-  - `state-model`: a sequence of variables representing the structure of the
-    nested function returned by the state function
-  - `body`: a function body making use of any symbol in the args above"
+  - `argv`: a vector of symbols to serve as the function's arguments.
+    The vector may be nested for sequence destructuring.
+
+  - `body`: a function body making use of any symbol in argv above"
   [argv body]
   (let [argv        (mapv commafy-arglist argv)
         js          (render/->JavaScript* body {})
@@ -334,11 +332,10 @@
 (defn- compile-native
   "Returns a natively-evaluated function that implements `body`, given:
 
-  - `params`: a seq of symbols equal in count to the original state function's
-    args
-  - `state-model`: a sequence of variables representing the structure of the
-    nested function returned by the state function
-  - `body`: a function body making use of any symbol in the args above"
+  - `argv`: a vector of symbols to serve as the function's arguments.
+    The vector may be nested for sequence destructuring.
+
+  - `body`: a function body making use of any symbol in argv above"
   [argv body]
   #?(:clj (eval (compile->clj argv body))
      :cljs (comp js->clj (apply js/Function (compile->js argv body)))))
@@ -347,11 +344,10 @@
   "Returns a Clojure function evaluated using SCI. The returned fn implements
   `body`, given:
 
-  - `params`: a seq of symbols equal in count to the original state function's
-    args
-  - `state-model`: a sequence of variables representing the structure of the
-    nested function returned by the state function
-  - `body`: a function body making use of any symbol in the args above"
+  - `argv`: a vector of symbols to serve as the function's arguments.
+    The vector may be nested for sequence destructuring.
+
+  - `body`: a function body making use of any symbol in argv above"
   ([argv body]
    (sci-eval
     (compile->clj argv body))))

--- a/src/emmy/expression/compile.cljc
+++ b/src/emmy/expression/compile.cljc
@@ -4,11 +4,10 @@
   "This namespace contains tools for compiling functions implemented with the
   numeric operations defined in [[emmy.generic]] down to fast, native
   functions."
-  (:require #?(:cljs [goog.string :refer [format]])
-            [clojure.set :as set]
+  (:require [clojure.string :as s]
             [clojure.walk :as w]
-            [emmy.expression :as x]
-            [emmy.expression.analyze :as a]
+            [emmy.expression.cse :refer [cse-form]]
+            [emmy.expression.render :as render]
             [emmy.function :as f]
             [emmy.generic :as g]
             [emmy.structure :as struct]
@@ -27,18 +26,18 @@
 ;;    to return a "numerical expression", a syntax tree representing the
 ;;    function's body:
 #_(let [f (fn [x] (g/sqrt
-                (g/+ (g/square (g/sin x))
-                     (g/square (g/cos x)))))]
-(= '(sqrt (+ (expt (sin x) 2) (expt (cos x) 2)))
-   (x/expression-of (f 'x))))
+                   (g/+ (g/square (g/sin x))
+                        (g/square (g/cos x)))))]
+    (= '(sqrt (+ (expt (sin x) 2) (expt (cos x) 2)))
+       (x/expression-of (f 'x))))
 
 ;; 2. `g/simplify` the new function body. Sometimes this results in large
 ;;    simplifications:
 
 #_(let [f (fn [x] (g/sqrt
-                (g/+ (g/square (g/sin x))
-                     (g/square (g/cos x)))))]
-  (v/= 1 (g/simplify (f 'x))))
+                   (g/+ (g/square (g/sin x))
+                        (g/square (g/cos x)))))]
+    (v/= 1 (g/simplify (f 'x))))
 
 ;; 3. Apply "common subexpression elimination". Any subexpression inside the
 ;;    new, simplified body that appears more than once gets extracted out into a
@@ -124,232 +123,6 @@
   sym->resolved-form
   (u/map-vals :sym compiled-fn-whitelist))
 
-;; ## Subexpression Elimination
-;;
-;; This section implements subexpression extraction and "elimination", the
-;; process we use to avoid redundant computation inside of a simplified function
-;; body.
-;;
-;; The goal of this process is to split some symbolic expression into:
-;;
-;; - a map of symbol -> redundant subexpression
-;; - a new expression with each redundant subexpr replaced with its
-;;   corresponding symbol.
-;;
-;; The invariant we want to achieve is that the new expression, rehydrated using
-;; the symbol->subexpression map, should be equivalent to the old expression.
-;;
-;; First, we write a function to determine how often each subexpression appears.
-;; Subexpressions that appear just once aren't worth extracting, but two
-;; appearances is enough.
-
-(defn- expr-frequencies
-  "Returns a map from distinct subexpressions in the supplied `expr` to the
-  number of times each appears.
-
-  If `skip?` returns true given a subexpression it won't be included as a key in
-  the returned map."
-  [expr skip?]
-  (let [children (partial filter seq?)]
-    (->> (rest
-          (tree-seq seq? children expr))
-         (remove skip?)
-         (frequencies))))
-
-;; The next function assumes that we have the two data structures we referenced
-;; earlier. We want to be careful that we only generate and bind subexpressions
-;; that are actually used in the final computation.
-;;
-;; `discard-unferenced-syms` ensures this by removing any entry from our
-;; replacement map that doesn't appear in the expression it's passed, or any
-;; subexpression referenced by a symbol in the expression, etc etc.
-;;
-;; The algorithm is:
-;;
-;; - consider the intersection of all variables in the replacement map and the
-;;   supplied expression, and store these into a map of "referenced" symbols.
-;;
-;; - Look up the corresponding subexpression for each of these symbols, and add
-;;   all potential replacements from each subexpression into the "referenced"
-;;   list, continuing this process recursively until all candidates are
-;;   exhausted.
-;;
-;; - Return subset of the original `sym->expr` by removing any key not found in
-;; - the accumulated "referenced" set.
-
-(defn- discard-unreferenced-syms
-  "Trims down a proposed map of `sym->expr` replacements (suitable for a let-binding,
-  say) to include only entries relevant to the supplied `expr`.
-
-  Accepts:
-
-  - `sym->expr`, a map of symbol -> symbolic expression
-  - `expr`, an expression that potentially contains symbols referenced in the
-    keyset of `sym->expr`
-
-  And returns a subset of `sym->expr` containing only entries where the
-  symbol-key is found in:
-
-  - the original `expr`, or
-  - in an expression referenced by a symbol in the original `expr`"
-  [sym->expr expr]
-  (let [syms        (u/keyset sym->expr)
-        lookup-syms (mapcat (comp x/variables-in sym->expr))]
-    (loop [referenced #{}
-           sym-batch  (-> (x/variables-in expr)
-                          (set/intersection syms))]
-      (if (empty? sym-batch)
-        (select-keys sym->expr referenced)
-        (let [referenced'   (set/union referenced sym-batch)
-              syms-in-exprs (-> (into #{} lookup-syms sym-batch)
-                                (set/intersection syms)
-                                (set/difference referenced'))]
-          (recur referenced' syms-in-exprs))))))
-
-;; This final function implements common subexpression extraction in
-;; continuation-passing-style. Pass it a callback and it will invoke the
-;; callback with the two arguments described above, and detailed below in its
-;; docstring.
-;;
-;; The algorithm is:
-;;
-;; - For every subexpression that appears more than once in the supplied
-;;   expression, generate a new, unique symbol.
-;;
-;; - Generate a new expression by replacing every subexpression in the supplied
-;;   expression with a symbol using the new mapping of symbol -> subexpression.
-;;
-;; - Recursively keep going until there are no more common subexpressions to
-;;   replace. At this point, discard all extra bindings (see
-;;   `discard-unreferenced-syms` above) and call the continuation function with
-;;   the /new/ slimmed expression, and a sorted-by-symbol list of binding pairs.
-;;
-;; These two return values satisfy the invariant we described above: the new
-;; expression, rehydrated using the symbol->subexpression map, should give us
-;; back the old expression.
-;;
-;; NOTE that the algorithm as implemented below uses a postwalk tree traversal!
-;; This is important, as it forces us to consider smaller subexpressions first.
-;; Consider some expression like:
-
-#_(+ (* (sin x) (cos x))
-   (* (sin x) (cos x))
-   (* (sin x) (cos x)))
-
-;; At first pass, we have three repeated subexpressions:
-;;
-;; - `(sin x)`
-;; - `(cos x)`
-;; - `(* (sin x) (cos x))`
-;;
-;; Postwalk traversal guarantees that we replace the `sin` and `cos` terms
-;; before the larger term that contains them both. And in fact the returned pair
-;; looks like:
-
-#_[(+ g3 g3 g3) ([g1 (sin x)] [g2 (cos x)] [g3 (* g1 g2)])]
-
-;; NOTE also that:
-;;
-;; - this is why the `:symbol-generator` below must generate symbols that sort
-;;   in the order they're generated. Else, the final binding vector might put
-;;   the `g3` term in the example above /before/ the smaller subexpressions it
-;;   uses.
-;;
-;; - This algorithm justifies `discard-unreferenced-syms` above. Each pass will
-;;   larger subexpressions like `'(* (sin x) (cos x))` that should never make it
-;;   out, since they never appear in this form (since they contain smaller
-;;   subexpressions).
-
-(def sortable-gensym
-  (a/monotonic-symbol-generator "G"))
-
-(defn extract-common-subexpressions
-  "Considers an S-expression from the point of view of optimizing its evaluation
-  by isolating common subexpressions into auxiliary variables.
-
-  Accepts:
-
-  - A symbolic expression `expr`
-  - a continuation fn `continue` of two arguments:
-    - a new equivalent expression with possibly some subexpressions replaced by
-      new variables (delivered by the supplied generator, see below)
-    - a seq of pairs of `[aux variable, subexpression]` used to reconstitute the
-      value.
-
-  Calls the continuation at completion and returns the continuation's value.
-
-  ### Optional Arguments
-
-  `:symbol-generator`: side-effecting function that returns a new, unique
-  variable name on each invocation. `sortable-gensym` by default.
-
-  NOTE that the symbols should appear in sorted order! Otherwise we can't
-  guarantee that the binding sequence passed to `continue` won't contain entries
-  that reference previous entries.
-
-  `:deterministic?`: if true, the function will assign aux variables by sorting
-  the string representations of each term before assignment. Otherwise, the
-  nondeterministic order of hash maps inside this function won't guarantee a
-  consistent variable naming convention in the returned function. For tests, set
-  `:deterministic? true`."
-  ([expr continue] (extract-common-subexpressions expr continue {}))
-  ([expr continue {:keys [symbol-generator deterministic?]
-                   :or {symbol-generator sortable-gensym}}]
-   (let [sort (if deterministic?
-                (partial sort-by (comp str vec first))
-                identity)]
-     (loop [x         expr
-            expr->sym {}]
-       (let [expr->count (expr-frequencies x expr->sym)
-             new-syms    (into {} (for [[k v] (sort expr->count)
-                                        :when (> v 1)]
-                                    [k (symbol-generator)]))]
-         (if (empty? new-syms)
-           (let [sym->expr (-> (set/map-invert expr->sym)
-                               (discard-unreferenced-syms x))]
-             (continue x (sort-by key sym->expr)))
-           (let [expr->sym' (merge expr->sym new-syms)]
-             (recur (w/postwalk-replace expr->sym' x)
-                    expr->sym'))))))))
-
-;; This final wrapper function invokes `extract-common-subexpressions` to turn a
-;; symbolic expression a new, valid Clojure(script) form that uses a `let`
-;; binding to bind any common subexpressions exposed during the above search.
-;;
-;; If there are no common subexpressions, `cse-form` will round-trip its input.
-
-(defn cse-form
-  "Given a symbolic expression `expr`, returns a new expression potentially
-  wrapped in a `let` binding with one binding per extracted common
-  subexpression.
-
-  ## Optional Arguments
-
-  `:symbol-generator`: side-effecting function that returns a new, unique symbol
-  on each invocation. These generated symbols are used to create unique binding
-  names for extracted subexpressions. `sortable-gensym` by default.
-
-  NOTE that the symbols should appear in sorted order! Otherwise we can't
-  guarantee that the binding sequence won't contain entries that reference
-  previous entries, resulting in \"Unable to resolve symbol\" errors.
-
-  `:deterministic?`: if true, the function will order the let-binding contents
-  by sorting the string representations of each term before assignment. If false
-  the function won't guarantee a consistent variable naming convention in the
-  returned function. For tests, we recommend `:deterministic? true`."
-  ([expr] (cse-form expr {}))
-  ([expr opts]
-   (letfn [(callback [new-expression bindings]
-             (let [n-bindings (count bindings)]
-               (if (pos? n-bindings)
-                 (let [binding-vec (into [] cat bindings)]
-                   (log/info
-                    (format "common subexpression elimination: %d expressions" n-bindings))
-                   `(let ~binding-vec
-                      ~new-expression))
-                 new-expression)))]
-     (extract-common-subexpressions expr callback opts))))
-
 (def ^{:private true
        :doc "Similar to [[compiled-fn-whitelist]], but restricted to numeric
   operations."}
@@ -380,21 +153,24 @@
 ;;
 ;; This library provides two compilation modes:
 ;;
-;; - Native compilation via `eval`
+;; - Native compilation via `eval` in Clojure, transpiling in JavaScript
 ;; - interpreted compilation via [SCI](https://github.com/borkdude/sci), the
 ;;   Small Clojure Interpreter.
+;; - Clojure source
+;; - JavaScript source
+;; - just asking for :source will provide the source in whichever environment
+;;   you're using
 ;;
-;; We default to SCI mode in CLJS, but :native in Clojure for performance.
+;; We default :native for performance.
 
 (def ^{:dynamic true
        :no-doc true}
   *mode*
-  #?(:clj :native
-     :cljs :sci))
+  :native)
 
 (def ^{:doc "Set of all supported compilation modes."}
   valid-modes
-  #{:sci :native :source})
+  #{:sci :native :source :js :clj})
 
 (defn validate-mode!
   "Given a keyword `mode` specifying a compilation mode, returns `mode` if valid,
@@ -440,7 +216,7 @@
 ;; The compiled version of a state function like
 
 #_(fn [mass g]
-  (fn [q]))
+    (fn [q]))
 
 ;; Has a signature like
 
@@ -463,7 +239,7 @@
                        :or {flatten? true
                             generic-params? true}}]
   (let [state (into [] (if flatten?
-                         (into [] (flatten state-model))
+                         (flatten state-model)
                          state-model))]
     (if generic-params?
       [state (into [] params)]
@@ -491,6 +267,31 @@
                  {'up struct/up
                   'down struct/down}}}))
 
+(defn- commafy-arglist
+  "Since JavaScript likes commas between array elements:
+
+   [a [b c [d e] f]] -> \"[a, b, c, d, e, f]\"       if flatten?
+   [a [b c [d e] f]] -> \"[a, [b, c, [d, e], f]]\"   if not flatten?
+
+   However, [] (which occurs in parameterless state functions)
+   will appear as \"_\" in the argument list. While it's not
+   wrong to destructure an empty list in JavaScript, nil is
+   not iterable, and so can't serve as an empty list argument
+   as it can in Clojure. Instead, we \"discard\" the argument
+   by letting it bind to a dummy name: in this way, either nil
+   or [] can serve as the empty argument"
+  [a]
+  (let [c (w/postwalk
+           (fn [f]
+             (if (sequential? f)
+               (if (seq f)
+                 (let [as (clojure.string/join ", " f)]
+                             (str "[" as "]"))
+                 "_")
+               (str f)))
+           a)]
+    c))
+
 (defn sci-eval
   "Given an unevaluated source code form `f-form` representing a function,
   evaluates `f-form` using the bindings in [[sci-context]].
@@ -499,31 +300,51 @@
   [f-form]
   (sci/eval-form (sci/fork sci-context) f-form))
 
-(defn- compile-state->source
-  "Returns a natively-evaluated Clojure function that implements `body`, given:
+(defn- compile->clj
+  "Returns Clojure source for a function that implements `body`, given:
 
   - `params`: a seq of symbols equal in count to the original state function's
     args
   - `state-model`: a sequence of variables representing the structure of the
     nested function returned by the state function
   - `body`: a function body making use of any symbol in the args above"
-  [params state-model body opts]
+  [argv body]
   (let [body (w/postwalk-replace sym->resolved-form body)]
-    `(fn ~(state-argv params state-model opts) ~body)))
+    `(fn [~@argv] ~body)))
 
-(defn- compile-state-native
-  "Returns a natively-evaluated Clojure function that implements `body`, given:
+(defn- compile->js
+  "Returns an array containing JavaScript source for a function that implements
+  `body` in a form suitable for the arguments of the Function constructor, given:
 
   - `params`: a seq of symbols equal in count to the original state function's
     args
   - `state-model`: a sequence of variables representing the structure of the
     nested function returned by the state function
   - `body`: a function body making use of any symbol in the args above"
-  [params state-model body opts]
-  (eval
-   (compile-state->source params state-model body opts)))
+  [argv body]
+  (let [argv        (mapv commafy-arglist argv)
+        js          (render/->JavaScript* body)
+        cs-bindings (s/join (for [[var val] (:vars js)]
+                              (str "  const " var " = " val ";\n")))
+        body        (str cs-bindings
+                         "  return "
+                         (:value js)
+                         ";")]
+    (conj argv body)))
 
-(defn- compile-state-sci
+(defn- compile-native
+  "Returns a natively-evaluated function that implements `body`, given:
+
+  - `params`: a seq of symbols equal in count to the original state function's
+    args
+  - `state-model`: a sequence of variables representing the structure of the
+    nested function returned by the state function
+  - `body`: a function body making use of any symbol in the args above"
+  [argv body]
+  #?(:clj (eval (compile->clj argv body))
+     :cljs (comp js->clj (apply js/Function (compile->js argv body)))))
+
+(defn- compile-sci
   "Returns a Clojure function evaluated using SCI. The returned fn implements
   `body`, given:
 
@@ -532,9 +353,9 @@
   - `state-model`: a sequence of variables representing the structure of the
     nested function returned by the state function
   - `body`: a function body making use of any symbol in the args above"
-  ([params state-model body opts]
+  ([argv body]
    (sci-eval
-    (compile-state->source params state-model body opts))))
+    (compile->clj argv body))))
 
 ;; ### State Fn Interface
 ;;
@@ -604,14 +425,17 @@
          body          (-> (g generic-state)
                            (g/simplify)
                            (v/freeze)
-                           (cse-form)
+                           #?(:clj (cse-form))  ;; JavaScript handles this in render
                            (apply-numeric-ops))
          compiler      (case (validate-mode! (or mode *mode*))
-                         :source compile-state->source
-                         :native compile-state-native
-                         :sci compile-state-sci)
-         compiled-fn   (compiler params generic-state body opts)]
-     (log/info "compiled state function in" (us/repr sw) "with mode" *mode*)
+                         :source #?(:clj compile->clj :cljs compile->js)
+                         :clj compile->clj
+                         :js compile->js
+                         :native compile-native
+                         :sci compile-sci)
+         argv          (state-argv params generic-state opts)
+         compiled-fn   (compiler argv body)]
+     (log/info "compiled state function in" (us/repr sw) "with mode" *mode* "and flatten" (:flatten? opts) "yielding" compiled-fn)
      compiled-fn)))
 
 ;; TODO: `compile-state-fn` should be more discerning in how it caches!
@@ -634,43 +458,6 @@
      (let [compiled (compile-state-fn* f params initial-state opts)]
        (swap! fn-cache assoc f compiled)
        compiled))))
-
-;; ## Non-State-Functions
-;;
-;; Compiled functions are excellent input for `definite-integral`, ODE solvers,
-;; single variable function minimization, root finding and more.
-;;
-;; The implementation and compilation steps are simpler than the state function
-;; versions above; the function you pass in has to take `n` symbolic arguments,
-;; that's it.
-
-(defn- compile->source
-  "Returns an unevaluated source code body function that implements `body`, given
-  some sequence `args` of argument symbols.
-
-  `body` should of course make use of the symbols in `args`."
-  [args body]
-  (let [body (w/postwalk-replace sym->resolved-form body)]
-    `(fn [~@args] ~body)))
-
-(defn- compile-native
-  "Returns a natively-evaluated Clojure function that implements `body`, given
-  some sequence `args` of argument symbols.
-
-  `body` should of course make use of the symbols in `args`."
-  [args body]
-  (eval
-   (compile->source args body)))
-
-(defn- compile-sci
-  "Returns a Clojure function evaluated
-  using [SCI](https://github.com/borkdude/sci) The returned fn implements
-  `body`, given some sequence `args` of argument symbols.
-
-  `body` should of course make use of the symbols in `args`."
-  [args body]
-  (sci-eval
-   (compile->source args body)))
 
 (defn- retrieve-arity [f]
   (let [[kwd n :as arity] (f/arity f)]
@@ -702,7 +489,9 @@
                       (cse-form)
                       (apply-numeric-ops))
          compiled (case (compiler-mode)
-                    :source (compile->source args body)
+                    :source (#?(:clj compile->clj :cljs compile->js) args body)
+                    :js (compile->js args body)
+                    :clj (compile->clj args body)
                     :native (compile-native args body)
                     :sci (compile-sci args body))]
      (log/info "compiled function of arity" n "in" (us/repr sw) "with mode" *mode*)

--- a/src/emmy/expression/compile.cljc
+++ b/src/emmy/expression/compile.cljc
@@ -200,7 +200,7 @@
 ;; Native compilation works on the JVM and in ClojureScript. Enable this mode
 ;; by wrapping your call in
 ;;
-;; (binding [*mode* :native] ,,,)`
+;; `(binding [*mode* :native] ,,,)`
 ;;
 ;; ## State Functions
 ;;
@@ -270,8 +270,7 @@
 (defn- commafy-arglist
   "Since JavaScript likes commas between array elements:
 
-   [a [b c [d e] f]] -> \"[a, b, c, d, e, f]\"       if flatten?
-   [a [b c [d e] f]] -> \"[a, [b, c, [d, e], f]]\"   if not flatten?
+   [a [b c [d e] f]] -> \"[a, [b, c, [d, e], f]]\"
 
    However, [] (which occurs in parameterless state functions)
    will appear as \"_\" in the argument list. While it's not
@@ -323,7 +322,7 @@
   - `body`: a function body making use of any symbol in the args above"
   [argv body]
   (let [argv        (mapv commafy-arglist argv)
-        js          (render/->JavaScript* body)
+        js          (render/->JavaScript* body {})
         cs-bindings (s/join (for [[var val] (:vars js)]
                               (str "  const " var " = " val ";\n")))
         body        (str cs-bindings
@@ -435,7 +434,7 @@
                          :sci compile-sci)
          argv          (state-argv params generic-state opts)
          compiled-fn   (compiler argv body)]
-     (log/info "compiled state function in" (us/repr sw) "with mode" *mode* "and flatten" (:flatten? opts) "yielding" compiled-fn)
+     (log/info "compiled state function in" (us/repr sw))
      compiled-fn)))
 
 ;; TODO: `compile-state-fn` should be more discerning in how it caches!

--- a/src/emmy/expression/cse.cljc
+++ b/src/emmy/expression/cse.cljc
@@ -1,0 +1,233 @@
+#_"SPDX-License-Identifier: GPL-3.0"
+
+(ns emmy.expression.cse
+  "This namespace implements subexpression extraction and \"elimination\", the
+  process we use to avoid redundant computation inside of a simplified function
+  body."
+  (:require #?(:cljs [goog.string :refer [format]])
+            [clojure.set :as set]
+            [clojure.walk :as w]
+            [emmy.expression :as x]
+            [emmy.expression.analyze :as a]
+            [emmy.util :as u]
+            [taoensso.timbre :as log]))
+
+;;  The goal of this process is to split some symbolic expression into:
+;;
+;;  - a map of symbol -> redundant subexpression
+;;  - a new expression with each redundant subexpr replaced with its
+;;    corresponding symbol.
+;;
+;;  The invariant we want to achieve is that the new expression, rehydrated using
+;;  the symbol->subexpression map, should be equivalent to the old expression.
+;;
+;;  First, we write a function to determine how often each subexpression appears.
+;;  Subexpressions that appear just once aren't worth extracting, but two
+;;  appearances is enough.
+
+(defn- expr-frequencies
+  "Returns a map from distinct subexpressions in the supplied `expr` to the
+  number of times each appears.
+
+  If `skip?` returns true given a subexpression it won't be included as a key in
+  the returned map."
+  [expr skip?]
+  (let [children (partial filter seq?)]
+    (->> (rest
+          (tree-seq seq? children expr))
+         (remove skip?)
+         (frequencies))))
+
+;; The next function assumes that we have the two data structures we referenced
+;; earlier. We want to be careful that we only generate and bind subexpressions
+;; that are actually used in the final computation.
+;;
+;; `discard-unferenced-syms` ensures this by removing any entry from our
+;; replacement map that doesn't appear in the expression it's passed, or any
+;; subexpression referenced by a symbol in the expression, etc etc.
+;;
+;; The algorithm is:
+;;
+;; - consider the intersection of all variables in the replacement map and the
+;;   supplied expression, and store these into a map of "referenced" symbols.
+;;
+;; - Look up the corresponding subexpression for each of these symbols, and add
+;;   all potential replacements from each subexpression into the "referenced"
+;;   list, continuing this process recursively until all candidates are
+;;   exhausted.
+;;
+;; - Return subset of the original `sym->expr` by removing any key not found in
+;; - the accumulated "referenced" set.
+
+(defn- discard-unreferenced-syms
+  "Trims down a proposed map of `sym->expr` replacements (suitable for a let-binding,
+  say) to include only entries relevant to the supplied `expr`.
+
+  Accepts:
+
+  - `sym->expr`, a map of symbol -> symbolic expression
+  - `expr`, an expression that potentially contains symbols referenced in the
+    keyset of `sym->expr`
+
+  And returns a subset of `sym->expr` containing only entries where the
+  symbol-key is found in:
+
+  - the original `expr`, or
+  - in an expression referenced by a symbol in the original `expr`"
+  [sym->expr expr]
+  (let [syms        (u/keyset sym->expr)
+        lookup-syms (mapcat (comp x/variables-in sym->expr))]
+    (loop [referenced #{}
+           sym-batch  (-> (x/variables-in expr)
+                          (set/intersection syms))]
+      (if (empty? sym-batch)
+        (select-keys sym->expr referenced)
+        (let [referenced'   (set/union referenced sym-batch)
+              syms-in-exprs (-> (into #{} lookup-syms sym-batch)
+                                (set/intersection syms)
+                                (set/difference referenced'))]
+          (recur referenced' syms-in-exprs))))))
+
+;; This final function implements common subexpression extraction in
+;; continuation-passing-style. Pass it a callback and it will invoke the
+;; callback with the two arguments described above, and detailed below in its
+;; docstring.
+;;
+;; The algorithm is:
+;;
+;; - For every subexpression that appears more than once in the supplied
+;;   expression, generate a new, unique symbol.
+;;
+;; - Generate a new expression by replacing every subexpression in the supplied
+;;   expression with a symbol using the new mapping of symbol -> subexpression.
+;;
+;; - Recursively keep going until there are no more common subexpressions to
+;;   replace. At this point, discard all extra bindings (see
+;;   `discard-unreferenced-syms` above) and call the continuation function with
+;;   the /new/ slimmed expression, and a sorted-by-symbol list of binding pairs.
+;;
+;; These two return values satisfy the invariant we described above: the new
+;; expression, rehydrated using the symbol->subexpression map, should give us
+;; back the old expression.
+;;
+;; NOTE that the algorithm as implemented below uses a postwalk tree traversal!
+;; This is important, as it forces us to consider smaller subexpressions first.
+;; Consider some expression like:
+
+#_(+ (* (sin x) (cos x))
+     (* (sin x) (cos x))
+     (* (sin x) (cos x)))
+
+;; At first pass, we have three repeated subexpressions:
+;;
+;; - `(sin x)`
+;; - `(cos x)`
+;; - `(* (sin x) (cos x))`
+;;
+;; Postwalk traversal guarantees that we replace the `sin` and `cos` terms
+;; before the larger term that contains them both. And in fact the returned pair
+;; looks like:
+
+#_[(+ g3 g3 g3) ([g1 (sin x)] [g2 (cos x)] [g3 (* g1 g2)])]
+
+;; NOTE also that:
+;;
+;; - this is why the `:symbol-generator` below must generate symbols that sort
+;;   in the order they're generated. Else, the final binding vector might put
+;;   the `g3` term in the example above /before/ the smaller subexpressions it
+;;   uses.
+;;
+;; - This algorithm justifies `discard-unreferenced-syms` above. Each pass will
+;;   larger subexpressions like `'(* (sin x) (cos x))` that should never make it
+;;   out, since they never appear in this form (since they contain smaller
+;;   subexpressions).
+
+(def sortable-gensym
+  (a/monotonic-symbol-generator "G"))
+
+(defn extract-common-subexpressions
+  "Considers an S-expression from the point of view of optimizing its evaluation
+  by isolating common subexpressions into auxiliary variables.
+
+  Accepts:
+
+  - A symbolic expression `expr`
+  - a continuation fn `continue` of two arguments:
+    - a new equivalent expression with possibly some subexpressions replaced by
+      new variables (delivered by the supplied generator, see below)
+    - a seq of pairs of `[aux variable, subexpression]` used to reconstitute the
+      value.
+
+  Calls the continuation at completion and returns the continuation's value.
+
+  ### Optional Arguments
+
+  `:symbol-generator`: side-effecting function that returns a new, unique
+  variable name on each invocation. `sortable-gensym` by default.
+
+  NOTE that the symbols should appear in sorted order! Otherwise we can't
+  guarantee that the binding sequence passed to `continue` won't contain entries
+  that reference previous entries.
+
+  `:deterministic?`: if true, the function will assign aux variables by sorting
+  the string representations of each term before assignment. Otherwise, the
+  nondeterministic order of hash maps inside this function won't guarantee a
+  consistent variable naming convention in the returned function. For tests, set
+  `:deterministic? true`."
+  ([expr continue] (extract-common-subexpressions expr continue {}))
+  ([expr continue {:keys [symbol-generator deterministic?]
+                   :or {symbol-generator sortable-gensym}}]
+   (let [sort (if deterministic?
+                (partial sort-by (comp str vec first))
+                identity)]
+     (loop [x         expr
+            expr->sym {}]
+       (let [expr->count (expr-frequencies x expr->sym)
+             new-syms    (into {} (for [[k v] (sort expr->count)
+                                        :when (> v 1)]
+                                    [k (symbol-generator)]))]
+         (if (empty? new-syms)
+           (let [sym->expr (-> (set/map-invert expr->sym)
+                               (discard-unreferenced-syms x))]
+             (continue x (sort-by key sym->expr)))
+           (let [expr->sym' (merge expr->sym new-syms)]
+             (recur (w/postwalk-replace expr->sym' x)
+                    expr->sym'))))))))
+
+;; This final wrapper function invokes `extract-common-subexpressions` to turn a
+;; symbolic expression a new, valid Clojure(script) form that uses a `let`
+;; binding to bind any common subexpressions exposed during the above search.
+;;
+;; If there are no common subexpressions, `cse-form` will round-trip its input.
+
+(defn cse-form
+  "Given a symbolic expression `expr`, returns a new expression potentially
+  wrapped in a `let` binding with one binding per extracted common
+  subexpression.
+
+  ## Optional Arguments
+
+  `:symbol-generator`: side-effecting function that returns a new, unique symbol
+  on each invocation. These generated symbols are used to create unique binding
+  names for extracted subexpressions. `sortable-gensym` by default.
+
+  NOTE that the symbols should appear in sorted order! Otherwise we can't
+  guarantee that the binding sequence won't contain entries that reference
+  previous entries, resulting in \"Unable to resolve symbol\" errors.
+
+  `:deterministic?`: if true, the function will order the let-binding contents
+  by sorting the string representations of each term before assignment. If false
+  the function won't guarantee a consistent variable naming convention in the
+  returned function. For tests, we recommend `:deterministic? true`."
+  ([expr] (cse-form expr {}))
+  ([expr opts]
+   (letfn [(callback [new-expression bindings]
+             (let [n-bindings (count bindings)]
+               (if (pos? n-bindings)
+                 (let [binding-vec (into [] cat bindings)]
+                   (log/info
+                    (format "common subexpression elimination: %d expressions" n-bindings))
+                   `(let ~binding-vec
+                      ~new-expression))
+                 new-expression)))]
+     (extract-common-subexpressions expr callback opts))))

--- a/src/emmy/expression/render.cljc
+++ b/src/emmy/expression/render.cljc
@@ -693,24 +693,3 @@
         (print ";\n"))
       (print "  return" value)
       (print ";\n}"))))
-
-(comment
-
-  (doseq [[var val] new-vars]
-    (print "  var ")
-    (print (str var " = "))
-    (print (R val))
-    (print ";\n"))
-(print "  return ")
-(print (R new-expression))
-(print ";\n}")
-
-  (let [xs '(+ (* x y z)
-               (* x y z)
-               (- (* a b (sin c))
-
-                  (/ d g)))]
-    (print (->JavaScript xs
-                         :deterministic? true
-                         :symbol-generator (make-symbol-generator "p"))))
-  )

--- a/src/emmy/expression/render.cljc
+++ b/src/emmy/expression/render.cljc
@@ -587,7 +587,12 @@
              "\n\\end{equation}"))
       tex-string)))
 
-(def ->JavaScript*
+(def ^{:doc "Converts an expression to JavaScript, and returns the
+      result in a map containing `params` (list of the unbound symbols),
+      `vars` (sequence of [var value] pairs representing the output of
+      common subexpression analysis), and `body`. These pieces may be
+      assembled into a JS function in different ways."}
+  ->JavaScript*
   (let [operators-known '#{+ - * /
                            sin cos tan
                            asin acos atan

--- a/src/emmy/numerical/ode.cljc
+++ b/src/emmy/numerical/ode.cljc
@@ -190,12 +190,12 @@
         flat-initial-state (flatten initial-state)
         derivative-fn      (if compile?
                              (let [f' (c/compile-state-fn state-derivative derivative-args initial-state)]
-                               (fn [y] (f' y derivative-args)))
+                               (fn [y]
+                                 (f' y (or derivative-args []))))
                              (do (log/warn "Not compiling function for ODE analysis")
                                  (let [d:dt (apply state-derivative derivative-args)
                                        array->state #(struct/unflatten % initial-state)]
                                    (comp d:dt array->state))))
-
         equations        (fn [_ y out]
                            (us/start evaluation-time)
                            (swap! evaluation-count inc)

--- a/test/emmy/expression/compile_test.cljc
+++ b/test/emmy/expression/compile_test.cljc
@@ -138,9 +138,6 @@
 
         (testing "bind gensym to `identity` so we can check the result."
           (binding [c/*mode* :source]
-            ;; we compile twice because in mode :native we'd get JS source
-            ;; in a JS environment, and that can't be evaluated by sci.
-            ;; It may be that the sci environment has been made obsolete.
             (let [[f-source clj-source] (with-redefs [gensym (fn
                                                                ([] (clojure.core/gensym))
                                                                ([x] x))]

--- a/test/emmy/expression/compile_test.cljc
+++ b/test/emmy/expression/compile_test.cljc
@@ -1,9 +1,7 @@
 #_"SPDX-License-Identifier: GPL-3.0"
 
 (ns emmy.expression.compile-test
-  (:require #?(:cljs [goog.string :refer [format]])
-            [clojure.test :refer [is deftest testing]]
-            [clojure.walk :as w]
+  (:require [clojure.test :refer [is deftest testing]]
             [emmy.abstract.number]
             [emmy.expression.compile :as c]
             [emmy.generic :as g]
@@ -54,17 +52,23 @@
 
         (testing "bind gensym to `identity` so we can check the result."
           (binding [c/*mode* :source]
-            (let [f-source (c/compile-state-fn*
-                            f params initial-state
-                            {:gensym-fn identity})]
-              (is (= `(fn [[~'y] [~'p]]
-                        (vector (+ (* ~'p ~'y) (* 0.5 ~'p))))
+            (let [compiler #(c/compile-state-fn*
+                             f params initial-state
+                             {:gensym-fn identity})
+                  f-source (compiler)
+                  clj-source (binding [c/*mode* :clj]
+                               (compiler))]
+              (println "clj-source " clj-source)
+              (is (= #?(:clj `(fn [[~'y] [~'p]]
+                                (vector (+ (* ~'p ~'y) (* 0.5 ~'p))))
+                        :cljs ["[y]" "[p]" "  return [p * y + 0.5 * p];"])
                      f-source)
-                  "source code!")
+                  "source code for your native language!")
 
               (binding [c/*mode* :native]
-                (is (= `(fn [[~'y] [~'p]]
-                          (vector (+ (* ~'p ~'y) (* 0.5 ~'p))))
+                (is (= #?(:clj `(fn [[~'y] [~'p]]
+                                  (vector (+ (* ~'p ~'y) (* 0.5 ~'p))))
+                          :cljs ["[y]" "[p]" "  return [p * y + 0.5 * p];"])
                        (c/compile-state-fn*
                         f params initial-state
                         {:gensym-fn identity
@@ -78,7 +82,7 @@
                              :mode :invalid}))
                   "explicit invalid modes will throw!")
 
-              (is (= expected ((c/sci-eval f-source)
+              (is (= expected ((c/sci-eval clj-source)
                                initial-state params))
                   "source compiles to SCI and gives us the desired result."))))))
 
@@ -95,8 +99,9 @@
               params [3]
               initial-state (up 1 (down 2 (down 4 (up 1))))]
 
-          (is (= `(fn ~'[[y1 [y2 [y3 [y4]]]]]
-                    (vector (+ (* 3.0 ~'y1) 1.5)))
+          (is (= #?(:clj `(fn ~'[[y1 [y2 [y3 [y4]]]]]
+                            (vector (+ (* 3.0 ~'y1) 1.5)))
+                    :cljs ["[y1, [y2, [y3, [y4]]]]" "  return [3 * y1 + 1.5];"])
                  (c/compile-state-fn*
                   f params initial-state
                   {:flatten? false
@@ -104,14 +109,15 @@
                    :gensym-fn (gensym-fn)}))
               "nested argument vector, no params.")
 
-          (is (= `(fn ~'[[y1 [y2 [y3 [y4]]]] [p5]]
-                    (vector (+ (* ~'p5 ~'y1) (* 0.5 ~'p5))))
+          (is (= #?(:clj `(fn ~'[[y1 [y2 [y3 [y4]]]] [p5]]
+                            (vector (+ (* ~'p5 ~'y1) (* 0.5 ~'p5))))
+                    :cljs  ["[y1, [y2, [y3, [y4]]]]" "[p5]" "  return [p5 * y1 + 0.5 * p5];"])
                  (c/compile-state-fn*
                   f params initial-state
                   {:flatten? false
                    :generic-params? true
                    :gensym-fn (gensym-fn)}))
-              "nested argument vector, no params.")))))
+              "nested argument vector, params.")))))
 
   (testing "non-state-fns"
     (let [f (fn [x] (up (g/+ (g/cube x) (g/sin x))))
@@ -128,31 +134,38 @@
 
         (testing "bind gensym to `identity` so we can check the result."
           (binding [c/*mode* :source]
-            (let [f-source (with-redefs [gensym (fn
-                                                  ([] (clojure.core/gensym))
-                                                  ([x] x))]
-                             (c/compile-fn f))]
-              (is (= `(fn [~'x]
-                        (vector
-                         (+ (~'Math/pow ~'x 3.0)
-                            (~'Math/sin ~'x))))
+            ;; we compile twice because in mode :native we'd get JS source
+            ;; in a JS environment, and that can't be evaluated by sci.
+            ;; It may be that the sci environment has been made obsolete.
+            (let [[f-source clj-source] (with-redefs [gensym (fn
+                                                               ([] (clojure.core/gensym))
+                                                               ([x] x))]
+                             [(c/compile-fn f)
+                              (binding [c/*mode* :clj] (c/compile-fn f))])]
+              (is (= #?(:clj `(fn [~'x]
+                                (vector
+                                 (+ (~'Math/pow ~'x 3.0)
+                                    (~'Math/sin ~'x))))
+                        :cljs ["x" "  return [Math.pow(x, 3) + Math.sin(x)];"])
                      f-source)
-                  "source code!")
+                  "source code in your native language!")
 
-              (is (= expected ((c/sci-eval f-source) 10))
+              (is (= expected ((c/sci-eval clj-source) 10))
                   "source compiles to SCI and gives us the desired result."))
 
             (with-redefs [gensym (fn
                                    ([] (clojure.core/gensym))
                                    ([x] x))]
-              (is (= `(fn [~'x] (+ (* -1.0 ~'x) 28.0))
+              (is (= #?(:clj `(fn [~'x] (+ (* -1.0 ~'x) 28.0))
+                        :cljs ["x" "  return - x + 28;"])
                      (c/compile-fn
                       (fn [x]
                         (g/- (g/* 8 (g/+ (g// 1 2) 3))
                              x))))
                   "all remaining numerical literals are doubles.")
 
-              (is (= `(fn [~'x] (vector 2.0 (+ ~'x 0.5)))
+              (is (= #?(:clj `(fn [~'x] (vector 2.0 (+ ~'x 0.5)))
+                        :cljs ["x" "  return [2, x + 0.5];"])
                      (c/compile-fn
                       (fn [x]
                         (up 2 (g/+ (g// 1 2) x)))))
@@ -220,86 +233,3 @@
         (is (v/= ((sf 1) t) (cf (flatten t) [1])))
         (is (v/= ((sf 2) s) (cf (flatten s) [2])))
         (is (v/= ((sf 2) t) (cf (flatten t) [2])))))))
-
-(defn ^:private make-generator
-  [s]
-  (let [i (atom 0)]
-    (fn []
-      (symbol (format "%s%d" s (swap! i inc))))))
-
-(defn- rehydrate
-  "Takes a slimmed-down expression and a potentially-multi-level substitution map
-  and rebuilds the original expression."
-  [slimmed sym->expr]
-  (let [substitute (partial w/postwalk-replace sym->expr)]
-    (reduce #(if (= %1 %2) (reduced %1) %2)
-            (iterate substitute slimmed))))
-
-(deftest subexp-tests
-  (is (= '[(* g1 (+ x z) g1) ([g1 (+ x y)])]
-         (c/extract-common-subexpressions
-          '(* (+ x y) (+ x z) (+ x y))
-          vector
-          {:deterministic? true
-           :symbol-generator (make-generator "g")}))
-      "common (+ x y) variable is extracted.")
-
-  (let [expr '(+ (* (sin x) (cos x))
-                 (* (sin x) (cos x))
-                 (* (sin x) (cos x)))
-        opts {:deterministic? true
-              :symbol-generator (make-generator "g")}
-        slimmed '(+ g4 g4 g4)
-        expected-subs '([g2 (cos x)]
-                        [g3 (sin x)]
-                        [g4 (* g3 g2)])
-
-        sym->subexpr  (into {} expected-subs)]
-    (is (= [slimmed expected-subs]
-           (c/extract-common-subexpressions expr vector opts))
-        "nested subexpressions are extracted in order, and the substitution map
-        is suitable for a let binding (and has no extra variables).")
-
-    (is (= expr (rehydrate slimmed sym->subexpr))
-        "Rehydrating the slimmed expression should result in the original
-        expression."))
-
-  (let [expr '(+ (sin x) (expt (sin x) 2)
-                 (cos x) (sqrt (cos x)))
-        opts {:deterministic? true
-              :symbol-generator (make-generator "K")}
-        slimmed '(+ K2 (expt K2 2) K1 (sqrt K1))
-        expected-subs '([K1 (cos x)]
-                        [K2 (sin x)])]
-    (is (= expr (rehydrate slimmed (into {} expected-subs)))
-        "The substitutions are correct.")
-
-    (is (= [slimmed expected-subs]
-           (c/extract-common-subexpressions expr vector opts))
-        "subexpressions are again extracted in order.")))
-
-(def letsym
-  #?(:clj 'clojure.core/let :cljs 'cljs.core/let))
-
-(deftest subexp-compile-tests
-  (let [expr '(+ (* (sin x) (cos x))
-                 (* (sin x) (cos x))
-                 (* (sin x) (cos x))
-                 (sin x)
-                 (expt (sin x) 2)
-                 (cos x)
-                 (sqrt (cos x))
-                 (tan x))]
-    (is (= (list letsym
-                 '[g2 (sin x)
-                   g3 (cos x)
-                   g4 (* g2 g3)]
-                 '(+ g4 g4 g4
-                     g2 (expt g2 2)
-                     g3 (sqrt g3) (tan x)))
-           (c/cse-form expr {:symbol-generator (make-generator "g")}))
-        "Bindings appear in the correct order for subs.")
-
-    (is (= '(+ a b (sin x) (cos y))
-           (c/cse-form '(+ a b (sin x) (cos y))))
-        "No substitutions means no let binding.")))

--- a/test/emmy/expression/cse_test.cljc
+++ b/test/emmy/expression/cse_test.cljc
@@ -1,0 +1,88 @@
+(ns emmy.expression.cse-test
+  (:require #?(:cljs [goog.string :refer [format]])
+            [clojure.test :refer [is deftest]]
+            [clojure.walk :as w]
+            [emmy.expression.cse :as c]))
+
+(defn ^:private make-generator
+  [s]
+  (let [i (atom 0)]
+    (fn []
+      (symbol (format "%s%d" s (swap! i inc))))))
+
+(defn- rehydrate
+  "Takes a slimmed-down expression and a potentially-multi-level substitution map
+  and rebuilds the original expression."
+  [slimmed sym->expr]
+  (let [substitute (partial w/postwalk-replace sym->expr)]
+    (reduce #(if (= %1 %2) (reduced %1) %2)
+            (iterate substitute slimmed))))
+
+(deftest subexp-tests
+  (is (= '[(* g1 (+ x z) g1) ([g1 (+ x y)])]
+         (c/extract-common-subexpressions
+          '(* (+ x y) (+ x z) (+ x y))
+          vector
+          {:deterministic? true
+           :symbol-generator (make-generator "g")}))
+      "common (+ x y) variable is extracted.")
+
+  (let [expr '(+ (* (sin x) (cos x))
+                 (* (sin x) (cos x))
+                 (* (sin x) (cos x)))
+        opts {:deterministic? true
+              :symbol-generator (make-generator "g")}
+        slimmed '(+ g4 g4 g4)
+        expected-subs '([g2 (cos x)]
+                        [g3 (sin x)]
+                        [g4 (* g3 g2)])
+
+        sym->subexpr  (into {} expected-subs)]
+    (is (= [slimmed expected-subs]
+           (c/extract-common-subexpressions expr vector opts))
+        "nested subexpressions are extracted in order, and the substitution map
+        is suitable for a let binding (and has no extra variables).")
+
+    (is (= expr (rehydrate slimmed sym->subexpr))
+        "Rehydrating the slimmed expression should result in the original
+        expression."))
+
+  (let [expr '(+ (sin x) (expt (sin x) 2)
+                 (cos x) (sqrt (cos x)))
+        opts {:deterministic? true
+              :symbol-generator (make-generator "K")}
+        slimmed '(+ K2 (expt K2 2) K1 (sqrt K1))
+        expected-subs '([K1 (cos x)]
+                        [K2 (sin x)])]
+    (is (= expr (rehydrate slimmed (into {} expected-subs)))
+        "The substitutions are correct.")
+
+    (is (= [slimmed expected-subs]
+           (c/extract-common-subexpressions expr vector opts))
+        "subexpressions are again extracted in order.")))
+
+(def letsym
+  #?(:clj 'clojure.core/let :cljs 'cljs.core/let))
+
+(deftest subexp-compile-tests
+  (let [expr '(+ (* (sin x) (cos x))
+                 (* (sin x) (cos x))
+                 (* (sin x) (cos x))
+                 (sin x)
+                 (expt (sin x) 2)
+                 (cos x)
+                 (sqrt (cos x))
+                 (tan x))]
+    (is (= (list letsym
+                 '[g2 (sin x)
+                   g3 (cos x)
+                   g4 (* g2 g3)]
+                 '(+ g4 g4 g4
+                     g2 (expt g2 2)
+                     g3 (sqrt g3) (tan x)))
+           (c/cse-form expr {:symbol-generator (make-generator "g")}))
+        "Bindings appear in the correct order for subs.")
+
+    (is (= '(+ a b (sin x) (cos y))
+           (c/cse-form '(+ a b (sin x) (cos y))))
+        "No substitutions means no let binding.")))


### PR DESCRIPTION
- move CSE to its own namespace to avoid the circular dependency compile->render->compile

- refactor JS rendering to allow compiler to use it

- adjust meaning of :native and :source compilation modes now you get what's compatible with your execution environment but you can also ask for a specific language, allowing tests to be bilingual