### PR TITLE
unify compile-fn and compile-state-fn; primitive mode for compiled fns

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,4 @@ public/
 /.calva
 /.lsp
 /.cpcache
+/.vscode

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,9 +36,9 @@
 
   - refactor JS rendering to allow compiler to use it
 
-  - adjust meaning of :native and :source compilation modes now you get
-    what's compatible with your execution environment but you can also
-    ask for a specific language, allowing tests to be bilingual
+  - adjust meaning of :native and :source compilation modes: now you get
+    what's compatible with your execution environment. You can also
+    ask for a specific language, allowing tests to be bilingual.
 
 - #100:
 

--- a/src/emmy/expression/compile.cljc
+++ b/src/emmy/expression/compile.cljc
@@ -489,7 +489,10 @@
   current runtime environment."
   [code]
   #?(:clj (eval (compile->clj code))
-     :cljs (comp js->clj (apply js/Function (compile->js code)))))
+     :cljs (let [g (apply js/Function (compile->js code))]
+             (if (= (:calling-convention code) :primitive)
+               g
+               (comp js->clj g)))))
 
 (defn- compile-sci
   "Returns a Clojure function evaluated using SCI. The returned fn implements
@@ -609,7 +612,7 @@
                                    cache?]
                             :or {mode *mode*
                                  calling-convention :structure
-                                 generic-params? true
+                                 generic-params? (boolean params)
                                  gensym-fn (a/monotonic-symbol-generator 4)
                                  deterministic? false
                                  cache? true}}]

--- a/src/emmy/expression/compile.cljc
+++ b/src/emmy/expression/compile.cljc
@@ -112,8 +112,6 @@
                              (- ~'x (~'Math/floor ~'x)))
                      :fn (fn [^double x]
                            (- x (Math/floor x)))}
-   'aset-double #?(:clj {:sym 'clojure.core/aset-double :f aset-double}
-                   :cljs {:sym 'cljs.core/aset :f aset})
    #?@(:cljs
        ;; JS-only entries.
        ['acosh {:sym 'Math/acosh :f #(Math/acosh %)}
@@ -343,7 +341,7 @@
 
 (defn- primitive-body
   "In the case of primitive calling convention, unrolls the source of the
-  vector-producing statement of the body into a sequence of `aset-double`
+  vector-producing statement of the body into a sequence of `aset`
   calls to populate the derivative output array. Returns an updated code
   object."
   [{:keys [calling-convention argv] :as code}]
@@ -363,7 +361,7 @@
            ;; of the primitive array denoted by `array-symbol `.
            [array-symbol exps]
            `(doto ~array-symbol
-              ~@(map-indexed (fn [i v] `(~'aset-double ~i ~v)) exps)))]
+              ~@(map-indexed (fn [i v] `(aset ~i ~v)) exps)))]
     (case calling-convention
       :primitive
       (update code :body (fn [body]
@@ -459,8 +457,8 @@
                         (throw (ex-info "Expecting a symbol (referring to a primitive array)"
                                         {:unexpected var})))
                       (doseq [[aset ix value] (z/rights z)]
-                        (when-not (= aset 'aset-double)
-                          (throw (ex-info "Expecting an aset-double statement"
+                        (when-not (= aset `aset)
+                          (throw (ex-info "Expecting an aset statement"
                                           {:unexpected aset})))
                         (swap! buffer conj (str "  " var "[" ix "] = " (render/->JavaScript value) ";")))
                       (z/next z))

--- a/src/emmy/expression/cse.cljc
+++ b/src/emmy/expression/cse.cljc
@@ -13,7 +13,7 @@
 ;;  The goal of this process is to split some symbolic expression into:
 ;;
 ;;  - a map of symbol -> redundant subexpression
-;;  - a new expression with each redundant subexpr replaced with its
+;;  - a new expression with each redundant subexpression replaced with its
 ;;    corresponding symbol.
 ;;
 ;;  The invariant we want to achieve is that the new expression, rehydrated using
@@ -40,7 +40,7 @@
 ;; earlier. We want to be careful that we only generate and bind subexpressions
 ;; that are actually used in the final computation.
 ;;
-;; `discard-unferenced-syms` ensures this by removing any entry from our
+;; `discard-unreferenced-syms` ensures this by removing any entry from our
 ;; replacement map that doesn't appear in the expression it's passed, or any
 ;; subexpression referenced by a symbol in the expression, etc etc.
 ;;
@@ -159,7 +159,7 @@
 
   `:gensym-fn`: side-effecting function that returns a new, unique
   variable name prefixed by its argument on each invocation.
-   `monotonic-symbol-genπerator` by default.
+   `monotonic-symbol-generator` by default.
 
   NOTE that the symbols should appear in sorted order! Otherwise we can't
   guarantee that the binding sequence passed to `continue` won't contain entries

--- a/src/emmy/numerical/ode.cljc
+++ b/src/emmy/numerical/ode.cljc
@@ -193,9 +193,9 @@
                              ;; so we might as well bake the parameters into the function
                              ;; body...but the compiled function cache currently ignores
                              ;; this. TODO: expand the memoization key
-                             (c/compile-state-fn* state-derivative derivative-args initial-state
-                                                  {:calling-convention :flat
-                                                   :generic-params? false})
+                             (c/compile-state-fn state-derivative derivative-args initial-state
+                                                 {:calling-convention :flat
+                                                  :generic-params? false})
                              (do (log/warn "Not compiling function for ODE analysis")
                                  (let [d:dt (apply state-derivative derivative-args)
                                        array->state #(struct/unflatten % initial-state)]

--- a/src/emmy/numerical/ode.cljc
+++ b/src/emmy/numerical/ode.cljc
@@ -22,11 +22,10 @@
 
 (defn- flatten-into-primitive-array
   "Copy the sequence `xs` into the primitive double array `arr`."
-  [arr xs]
-  (let [ix (atom -1)
-        asetter #?(:clj aset-double :cljs aset)]
-    (r/reduce (fn [a x]
-                (asetter a (swap! ix unchecked-inc) x)
+  [^doubles arr xs]
+  (let [ix (atom -1)]
+    (r/reduce (fn [^doubles a ^double x]
+                (aset a (swap! ix unchecked-inc) x)
                 a)
               arr
               (r/flatten xs))))
@@ -171,9 +170,7 @@
                           :rawFunction true})]
          (comp js->clj (.integrate solver x0 (double-array y0)))))))
 
-
-
-(defn- integration-opts
+(defn ^:no-doc integration-opts
   "Returns a map with the following kv pairs:
 
   - `:integrator` an instance of `GraggBulirschStoerIntegrator`

--- a/test/emmy/examples/double_pendulum_test.cljc
+++ b/test/emmy/examples/double_pendulum_test.cljc
@@ -86,14 +86,14 @@
           "  const _21 = Math.sin(_15);\n"
           "  const _22 = Math.pow(_21, 2.0);\n"
           "  return [1.0, [y04, y05], [(- l1 * m2 * _10 * _19 * _21 - l2 * m2 * _11 * _21 + g * m2 * _19 * _14 - g * m1 * _13 - g * m2 * _13) / (l1 * m2 * _22 + l1 * m1), (l2 * m2 * _11 * _19 * _21 + l1 * m1 * _10 * _21 + l1 * m2 * _10 * _21 + g * m1 * _19 * _13 + g * m2 * _19 * _13 - g * m1 * _14 - g * m2 * _14) / (l2 * m2 * _22 + l2 * m1)]];"))]
-       (c/compile-state-fn* double/state-derivative
-                            '[m1 m2 l1 l2 g]
-                            (up 't (up 'theta 'phi) (up 'thetadot 'phidot))
-                            {:mode :js
-                             :calling-convention :structure
-                             :generic-params? false
-                             :gensym-fn (a/monotonic-symbol-generator 2)
-                             :deterministic? true})))
+       (c/compile-state-fn double/state-derivative
+                           '[m1 m2 l1 l2 g]
+                           (up 't (up 'theta 'phi) (up 'thetadot 'phidot))
+                           {:mode :js
+                            :calling-convention :structure
+                            :generic-params? false
+                            :gensym-fn (a/monotonic-symbol-generator 2)
+                            :deterministic? true})))
 
 
   (is (= ["[y01, y02, y03, y04, y05]"
@@ -110,7 +110,7 @@
             "  const _26 = Math.sin(_20);\n"
             "  const _27 = Math.pow(_26, 2.0);\n"
             "  return [1.0, [y04, y05], [(- p07 * p08 * _15 * _24 * _26 - p07 * p09 * _16 * _26 + p07 * p10 * _24 * _19 - p06 * p10 * _18 - p07 * p10 * _18) / (p07 * p08 * _27 + p06 * p08), (p07 * p09 * _16 * _24 * _26 + p06 * p08 * _15 * _26 + p07 * p08 * _15 * _26 + p06 * p10 * _24 * _18 + p07 * p10 * _24 * _18 - p06 * p10 * _19 - p07 * p10 * _19) / (p07 * p09 * _27 + p06 * p09)]];"))]
-         (c/compile-state-fn*
+         (c/compile-state-fn
           double/state-derivative
           '[1 1 1 1 'g]
           (up 't (up 'theta 'phi) (up 'thetadot 'phidot))
@@ -158,7 +158,7 @@
                 "  const _60 = _18 * _20 * _23 * _56;\n"
                 "  const _62 = _60 + _59 + _58 + _32 + _34;\n"
                 "  return [1.0, [(- l_1 * y05 * _46 + l_2 * y04) / (_18 * l_2 * m_2 * _57 + _18 * l_2 * m_1), (- l_2 * m_2 * y04 * _46 + l_1 * m_1 * y05 + l_1 * m_2 * y05) / (l_1 * _20 * _23 * _57 + l_1 * _20 * m_1 * m_2)], [(- g * _19 * _20 * m_1 * _23 * _56 * _28 - g * _19 * _20 * _24 * _56 * _28 + 2.0 * g * _19 * _20 * _22 * m_2 * _55 * _28 + 4.0 * g * _19 * _20 * m_1 * _23 * _55 * _28 + 2.0 * g * _19 * _20 * _24 * _55 * _28 - g * _19 * _20 * Math.pow(m_1, 3.0) * _28 - 3.0 * g * _19 * _20 * _22 * m_2 * _28 - 3.0 * g * _19 * _20 * m_1 * _23 * _28 - g * _19 * _20 * _24 * _28 - l_1 * l_2 * m_2 * y04 * y05 * _55 * _50 + _18 * m_1 * _26 * _46 * _50 + _18 * m_2 * _26 * _46 * _50 + _20 * m_2 * _25 * _46 * _50 - l_1 * l_2 * m_1 * y04 * y05 * _50 - l_1 * l_2 * m_2 * y04 * y05 * _50) / _62, (- g * _18 * _21 * _24 * _56 * _29 - 2.0 * g * _18 * _21 * m_1 * _23 * _57 * _29 + 2.0 * g * _18 * _21 * _24 * _55 * _29 - g * _18 * _21 * _22 * m_2 * _29 - g * _18 * _21 * _24 * _29 + l_1 * l_2 * m_2 * y04 * y05 * _55 * _50 - _18 * m_1 * _26 * _46 * _50 - _18 * m_2 * _26 * _46 * _50 - _20 * m_2 * _25 * _46 * _50 + l_1 * l_2 * m_1 * y04 * y05 * _50 + l_1 * l_2 * m_2 * y04 * y05 * _50) / _62]];")]
-              (c/compile-state-fn*
+              (c/compile-state-fn
                #(e/Hamiltonian->state-derivative
                  (e/Lagrangian->Hamiltonian
                   (double/L 'm_1 'm_2 'l_1 'l_2 'g)))

--- a/test/emmy/examples/double_pendulum_test.cljc
+++ b/test/emmy/examples/double_pendulum_test.cljc
@@ -90,7 +90,7 @@
                             '[m1 m2 l1 l2 g]
                             (up 't (up 'theta 'phi) (up 'thetadot 'phidot))
                             {:mode :js
-                             :flatten? false
+                             :calling-convention :structure
                              :generic-params? false
                              :gensym-fn (a/monotonic-symbol-generator 2)
                              :deterministic? true})))
@@ -115,6 +115,7 @@
           '[1 1 1 1 'g]
           (up 't (up 'theta 'phi) (up 'thetadot 'phidot))
           {:mode :js
+           :calling-convention :flat
            :gensym-fn (a/monotonic-symbol-generator 2)
            :deterministic? true})))
 
@@ -164,5 +165,6 @@
                []
                (e/->H-state 't (up 'theta 'psi) (down 'p_theta 'p_psi))
                {:mode :js
+                :calling-convention :flat
                 :gensym-fn (a/monotonic-symbol-generator 2)
                 :deterministic? true}))))))

--- a/test/emmy/examples/driven_pendulum_test.cljc
+++ b/test/emmy/examples/driven_pendulum_test.cljc
@@ -129,7 +129,7 @@
              "  const _06 = Math.pow(l, 2.0);\n"
              "  const _08 = Math.sin(y02);\n"
              "  const _09 = Math.sin(_04);\n"
-             "  return [1.0, (a * l * m * omega * _09 * _08 + y03) / (_06 * m), (- Math.pow(a, 2.0) * l * m * Math.pow(omega, 2.0) * Math.pow(_09, 2.0) * _08 * _05 - a * omega * y03 * _09 * _05 - g * _06 * m * _08) / l];"))]
+             "  return [1.0, (a * l * m * omega * _08 * _09 + y03) / (_06 * m), (- Math.pow(a, 2.0) * l * m * Math.pow(omega, 2.0) * _08 * Math.pow(_09, 2.0) * _05 - a * omega * y03 * _09 * _05 - g * _06 * m * _08) / l];"))]
          (compile-state-fn
           #(e/Hamiltonian->state-derivative
             (e/Lagrangian->Hamiltonian

--- a/test/emmy/examples/driven_pendulum_test.cljc
+++ b/test/emmy/examples/driven_pendulum_test.cljc
@@ -58,15 +58,15 @@
       (is (= `(clojure.core/fn
                 [~'a09 ~'a10 ~'a11]
                 (clojure.core/let
-                 [~'_12 (~'Math/sin ~'y02)
-                  ~'y01 (clojure.core/aget ~'a09 0)
+                 [~'y01 (clojure.core/aget ~'a09 0)
                   ~'y02 (clojure.core/aget ~'a09 1)
                   ~'y03 (clojure.core/aget ~'a09 2)
                   ~'p04 (clojure.core/aget ~'a11 0)
                   ~'p05 (clojure.core/aget ~'a11 1)
                   ~'p06 (clojure.core/aget ~'a11 2)
                   ~'p07 (clojure.core/aget ~'a11 3)
-                  ~'p08 (clojure.core/aget ~'a11 4)]
+                  ~'p08 (clojure.core/aget ~'a11 4)
+                  ~'_12 (~'Math/sin ~'y02)]
                   (clojure.core/doto
                    ~'a10
                     (~aset-symbol 0 1.0)
@@ -100,7 +100,6 @@
   (is (= ["a09" "a10" "a11"
           (maybe-defloatify
            (str
-            "  const _12 = Math.sin(y02);\n"
             "  const y01 = a09[0];\n"
             "  const y02 = a09[1];\n"
             "  const y03 = a09[2];\n"
@@ -109,6 +108,7 @@
             "  const p06 = a11[2];\n"
             "  const p07 = a11[3];\n"
             "  const p08 = a11[4];\n"
+            "  const _12 = Math.sin(y02);\n"
             "  a10[0] = 1.0;\n"
             "  a10[1] = y03;\n"
             "  a10[2] = (p07 * Math.pow(p08, 2.0) * _12 * Math.cos(p08 * y01) - p06 * _12) / p05;"))]
@@ -129,7 +129,7 @@
              "  const _06 = Math.pow(l, 2.0);\n"
              "  const _08 = Math.sin(y02);\n"
              "  const _09 = Math.sin(_04);\n"
-             "  return [1.0, (a * l * m * omega * _08 * _09 + y03) / (_06 * m), (- Math.pow(a, 2.0) * l * m * Math.pow(omega, 2.0) * _08 * Math.pow(_09, 2.0) * _05 - a * omega * y03 * _09 * _05 - g * _06 * m * _08) / l];"))]
+             "  return [1.0, (a * l * m * omega * _09 * _08 + y03) / (_06 * m), (- Math.pow(a, 2.0) * l * m * Math.pow(omega, 2.0) * Math.pow(_09, 2.0) * _08 * _05 - a * omega * y03 * _09 * _05 - g * _06 * m * _08) / l];"))]
          (compile-state-fn
           #(e/Hamiltonian->state-derivative
             (e/Lagrangian->Hamiltonian

--- a/test/emmy/examples/driven_pendulum_test.cljc
+++ b/test/emmy/examples/driven_pendulum_test.cljc
@@ -38,12 +38,12 @@
 (deftest as-clojure
   (let [compile (fn [calling-convention]
                   (compile-state-fn driven/state-derivative
-                                     '[m l g a omega]
-                                     (up 't 'theta 'thetadot)
-                                     {:mode :clj
-                                      :gensym-fn (a/monotonic-symbol-generator 2)
-                                      :deterministic? true
-                                      :calling-convention calling-convention}))]
+                                    '[m l g a omega]
+                                    (up 't 'theta 'thetadot)
+                                    {:mode :clj
+                                     :gensym-fn (a/monotonic-symbol-generator 2)
+                                     :deterministic? true
+                                     :calling-convention calling-convention}))]
     (is (= `(fn [[~'y01 ~'y02 ~'y03] [~'p04 ~'p05 ~'p06 ~'p07 ~'p08]]
               (let [~'_09 (~'Math/sin ~'y02)]
                 (clojure.core/vector 1.0
@@ -54,35 +54,34 @@
                                        (clojure.core/* -1.0 ~'p06 ~'_09))
                                       ~'p05))))
            (compile :structure)))
-    (let [aset-symbol #?(:clj 'clojure.core/aset-double :cljs 'cljs.core/aset)]
-      (is (= `(clojure.core/fn
-                [~'a09 ~'a10 ~'a11]
-                (clojure.core/let
-                 [~'y01 (clojure.core/aget ~'a09 0)
-                  ~'y02 (clojure.core/aget ~'a09 1)
-                  ~'y03 (clojure.core/aget ~'a09 2)
-                  ~'p04 (clojure.core/aget ~'a11 0)
-                  ~'p05 (clojure.core/aget ~'a11 1)
-                  ~'p06 (clojure.core/aget ~'a11 2)
-                  ~'p07 (clojure.core/aget ~'a11 3)
-                  ~'p08 (clojure.core/aget ~'a11 4)
-                  ~'_12 (~'Math/sin ~'y02)]
-                  (clojure.core/doto
-                   ~'a10
-                    (~aset-symbol 0 1.0)
-                    (~aset-symbol 1 ~'y03)
-                    (~aset-symbol
-                     2
-                     (clojure.core//
-                      (clojure.core/+
-                       (clojure.core/*
-                        ~'p07
-                        (~'Math/pow ~'p08 2.0)
-                        ~'_12
-                        (~'Math/cos (clojure.core/* ~'p08 ~'y01)))
-                       (clojure.core/* -1.0 ~'p06 ~'_12))
-                      ~'p05)))))
-             (compile :primitive))))))
+    (is (= `(clojure.core/fn
+              [~'a09 ~'a10 ~'a11]
+              (clojure.core/let
+               [~'y01 (clojure.core/aget ~'a09 0)
+                ~'y02 (clojure.core/aget ~'a09 1)
+                ~'y03 (clojure.core/aget ~'a09 2)
+                ~'p04 (clojure.core/aget ~'a11 0)
+                ~'p05 (clojure.core/aget ~'a11 1)
+                ~'p06 (clojure.core/aget ~'a11 2)
+                ~'p07 (clojure.core/aget ~'a11 3)
+                ~'p08 (clojure.core/aget ~'a11 4)
+                ~'_12 (~'Math/sin ~'y02)]
+                (clojure.core/doto
+                 ~'a10
+                  (clojure.core/aset 0 1.0)
+                  (clojure.core/aset 1 ~'y03)
+                  (clojure.core/aset
+                   2
+                   (clojure.core//
+                    (clojure.core/+
+                     (clojure.core/*
+                      ~'p07
+                      (~'Math/pow ~'p08 2.0)
+                      ~'_12
+                      (~'Math/cos (clojure.core/* ~'p08 ~'y01)))
+                     (clojure.core/* -1.0 ~'p06 ~'_12))
+                    ~'p05)))))
+           (compile :primitive)))))
 
 (deftest as-javascript
   (is (= ["[y01, y02, y03]"

--- a/test/emmy/examples/driven_pendulum_test.cljc
+++ b/test/emmy/examples/driven_pendulum_test.cljc
@@ -7,7 +7,7 @@
             [emmy.env :as e :refer [up /]]
             [emmy.examples.driven-pendulum :as driven]
             [emmy.expression.analyze :as a]
-            [emmy.expression.compile :refer [compile-state-fn*]]
+            [emmy.expression.compile :refer [compile-state-fn]]
             [emmy.simplify :refer [hermetic-simplify-fixture]]))
 
 (use-fixtures :each hermetic-simplify-fixture)
@@ -35,6 +35,55 @@
       (driven/evolver {:t (/ 3 60) :dt (/ 1 60) :observe observe})
       (is (= 4 (count @o))))))
 
+(deftest as-clojure
+  (let [compile (fn [calling-convention]
+                  (compile-state-fn driven/state-derivative
+                                     '[m l g a omega]
+                                     (up 't 'theta 'thetadot)
+                                     {:mode :clj
+                                      :gensym-fn (a/monotonic-symbol-generator 2)
+                                      :deterministic? true
+                                      :calling-convention calling-convention}))]
+    (is (= `(fn [[~'y01 ~'y02 ~'y03] [~'p04 ~'p05 ~'p06 ~'p07 ~'p08]]
+              (let [~'_09 (~'Math/sin ~'y02)]
+                (clojure.core/vector 1.0
+                                     ~'y03
+                                     (clojure.core//
+                                      (clojure.core/+
+                                       (clojure.core/* ~'p07 (~'Math/pow ~'p08 2.0) ~'_09 (~'Math/cos (clojure.core/* ~'p08 ~'y01)))
+                                       (clojure.core/* -1.0 ~'p06 ~'_09))
+                                      ~'p05))))
+           (compile :structure)))
+    (let [aset-symbol #?(:clj 'clojure.core/aset-double :cljs 'cljs.core/aset)]
+      (is (= `(clojure.core/fn
+                [~'a09 ~'a10 ~'a11]
+                (clojure.core/let
+                 [~'_12 (~'Math/sin ~'y02)
+                  ~'y01 (clojure.core/aget ~'a09 0)
+                  ~'y02 (clojure.core/aget ~'a09 1)
+                  ~'y03 (clojure.core/aget ~'a09 2)
+                  ~'p04 (clojure.core/aget ~'a11 0)
+                  ~'p05 (clojure.core/aget ~'a11 1)
+                  ~'p06 (clojure.core/aget ~'a11 2)
+                  ~'p07 (clojure.core/aget ~'a11 3)
+                  ~'p08 (clojure.core/aget ~'a11 4)]
+                  (clojure.core/doto
+                   ~'a10
+                    (~aset-symbol 0 1.0)
+                    (~aset-symbol 1 ~'y03)
+                    (~aset-symbol
+                     2
+                     (clojure.core//
+                      (clojure.core/+
+                       (clojure.core/*
+                        ~'p07
+                        (~'Math/pow ~'p08 2.0)
+                        ~'_12
+                        (~'Math/cos (clojure.core/* ~'p08 ~'y01)))
+                       (clojure.core/* -1.0 ~'p06 ~'_12))
+                      ~'p05)))))
+             (compile :primitive))))))
+
 (deftest as-javascript
   (is (= ["[y01, y02, y03]"
           "[p04, p05, p06, p07, p08]"
@@ -42,10 +91,32 @@
             (str
              "  const _09 = Math.sin(y02);\n"
              "  return [1.0, y03, (p07 * Math.pow(p08, 2.0) * _09 * Math.cos(p08 * y01) - p06 * _09) / p05];"))]
-         (compile-state-fn* driven/state-derivative
+         (compile-state-fn driven/state-derivative
                             '[m l g a omega]
                             (up 't 'theta 'thetadot)
                             {:mode :js
+                             :gensym-fn (a/monotonic-symbol-generator 2)
+                             :deterministic? true})))
+  (is (= ["a09" "a10" "a11"
+          (maybe-defloatify
+           (str
+            "  const _12 = Math.sin(y02);\n"
+            "  const y01 = a09[0];\n"
+            "  const y02 = a09[1];\n"
+            "  const y03 = a09[2];\n"
+            "  const p04 = a11[0];\n"
+            "  const p05 = a11[1];\n"
+            "  const p06 = a11[2];\n"
+            "  const p07 = a11[3];\n"
+            "  const p08 = a11[4];\n"
+            "  a10[0] = 1.0;\n"
+            "  a10[1] = y03;\n"
+            "  a10[2] = (p07 * Math.pow(p08, 2.0) * _12 * Math.cos(p08 * y01) - p06 * _12) / p05;"))]
+         (compile-state-fn driven/state-derivative
+                            '[m l g a omega]
+                            (up 't 'theta 'thetadot)
+                            {:mode :js
+                             :calling-convention :primitive
                              :gensym-fn (a/monotonic-symbol-generator 2)
                              :deterministic? true})))
 
@@ -59,7 +130,7 @@
              "  const _08 = Math.sin(y02);\n"
              "  const _09 = Math.sin(_04);\n"
              "  return [1.0, (a * l * m * omega * _08 * _09 + y03) / (_06 * m), (- Math.pow(a, 2.0) * l * m * Math.pow(omega, 2.0) * _08 * Math.pow(_09, 2.0) * _05 - a * omega * y03 * _09 * _05 - g * _06 * m * _08) / l];"))]
-         (compile-state-fn*
+         (compile-state-fn
           #(e/Hamiltonian->state-derivative
             (e/Lagrangian->Hamiltonian
              (driven/L 'm 'l 'g 'a 'omega)))

--- a/test/emmy/expression/compile_test.cljc
+++ b/test/emmy/expression/compile_test.cljc
@@ -38,26 +38,25 @@
                 (g/* m t)))
           compile (fn [opts]
                     (c/compile-state-fn f '[m] (up 't (up 'x0 'x1) (up 'v0 'v1))
-                                         (merge {:gensym-fn (a/monotonic-symbol-generator 1)}
-                                                opts)))]
+                                        (merge {:gensym-fn (a/monotonic-symbol-generator 1)}
+                                               opts)))]
       (is (= `(fn [[~'y1 [~'y2 ~'y3] [~'y4 ~'y5]] [~'p6]] (* ~'p6 ~'y1))
              (compile {:mode :clj :calling-convention :structure})))
       (is (= `(fn [[~'y1 ~'y2 ~'y3 ~'y4 ~'y5] [~'p6]] (* ~'p6 ~'y1))
              (compile {:mode :clj :calling-convention :flat})))
-      (let [aset-symbol #?(:clj 'clojure.core/aset-double :cljs 'cljs.core/aset)]
-        (is (= `(fn [~'a7 ~'a8 ~'a9]
-                  (let [~'y1 (aget ~'a7 0)
-                        ~'y2 (aget ~'a7 1)
-                        ~'y3 (aget ~'a7 2)
-                        ~'y4 (aget ~'a7 3)
-                        ~'y5 (aget ~'a7 4)
-                        ~'p6 (aget ~'a9 0)]
-                    (doto ~'a8 (~aset-symbol 0 (* ~'p6 ~'y1)))))
-               (compile {:mode :clj :calling-convention :primitive}))))
+      (is (= `(fn [~'a7 ~'a8 ~'a9]
+                (let [~'y1 (aget ~'a7 0)
+                      ~'y2 (aget ~'a7 1)
+                      ~'y3 (aget ~'a7 2)
+                      ~'y4 (aget ~'a7 3)
+                      ~'y5 (aget ~'a7 4)
+                      ~'p6 (aget ~'a9 0)]
+                  (doto ~'a8 (aset 0 (* ~'p6 ~'y1)))))
+             (compile {:mode :clj :calling-convention :primitive})))
       (is (= ["[y1, [y2, y3], [y4, y5]]" "[p6]" "  return p6 * y1;"]
-           (compile {:mode :js :calling-convention :structure})))
+             (compile {:mode :js :calling-convention :structure})))
       (is (= ["[y1, y2, y3, y4, y5]" "[p6]" "  return p6 * y1;"]
-           (compile {:mode :js :calling-convention :flat})))
+             (compile {:mode :js :calling-convention :flat})))
       (is (= ["a7"
               "a8"
               "a9"

--- a/test/emmy/numerical/ode_test.cljc
+++ b/test/emmy/numerical/ode_test.cljc
@@ -37,14 +37,14 @@
           (is (near? (Math/exp 1) (first result)))))))
 
   (testing "y' = y, new interface"
-    (let [f (o/stream-integrator (fn [_ y out] (aset-double out 0 (aget y 0))) 0 [1] {:epsilon 1e-8})]
+    (let [f (o/stream-integrator (fn [_ ^doubles y ^doubles out] (aset-double out 0 (aget y 0))) 0 [1] {:epsilon 1e-8})]
       (doseq [x (range 0 1 0.01)]
         (let [[ex] (f x)]
           (is (near? (Math/exp x) ex))))
       (f)))
 
   (testing "y'' = - y, new interface"
-    (let [f (o/stream-integrator (fn [_ y out]
+    (let [f (o/stream-integrator (fn [_ ^doubles y ^doubles out]
                                    (aset-double out 0 (aget y 1))
                                    (aset-double out 1 (- (aget y 0))))
                                  0 [1 0] {:epsilon 1e-8})]
@@ -55,7 +55,7 @@
       (f)))
 
   (testing "stream integrator throws if used backwards"
-    (let [f (o/stream-integrator (fn [_ y out]
+    (let [f (o/stream-integrator (fn [_ ^doubles y ^doubles out]
                                    (aset-double out 0 (aget y 0)))
                                  0 [1] {:epsilon 1e-8})]
       (is (f 10))

--- a/test/emmy/sicm/ch3_test.cljc
+++ b/test/emmy/sicm/ch3_test.cljc
@@ -159,7 +159,7 @@
                 "  const _12 = Math.pow(_08, 2.0);\n"
                 "  const _13 = Math.pow(_09, 2.0);\n"
                 "  return [1.0, [y05 / A, (- y07 * _09 + y06) / (A * _12), (A * y07 * _12 + C * y07 * _13 - C * y06 * _09) / (A * C * _12)], [(A * gMR * Math.pow(_09, 4.0) - 2.0 * A * gMR * _13 - y06 * y07 * _13 + Math.pow(y06, 2.0) * _09 + Math.pow(y07, 2.0) * _09 + A * gMR - y06 * y07) / (A * Math.pow(_08, 3.0)), 0.0, 0.0]];"))]
-             (c/compile-state-fn* (fn [] sysder) [] top-state
+             (c/compile-state-fn (fn [] sysder) [] top-state
                {:mode :js
                 :calling-convention :flat
                 :gensym-fn (a/monotonic-symbol-generator 2)})))))
@@ -204,7 +204,7 @@
                   "  const _08 = omega * y01;\n"
                   "  const _09 = Math.sin(_08);\n"
                   "  return [1, (a * l * m * omega * _09 * _04 + y03) / (_06 * m), (- Math.pow(a, 2.0) * l * m * Math.pow(omega, 2.0) * Math.pow(_09, 2.0) * _04 * _05 - a * omega * y03 * _09 * _05 - g * _06 * m * _04) / l];"))]
-               (c/compile-state-fn*
+               (c/compile-state-fn
                 (fn []
                   (e/Hamiltonian->state-derivative
                    (e/Lagrangian->Hamiltonian

--- a/test/emmy/sicm/ch3_test.cljc
+++ b/test/emmy/sicm/ch3_test.cljc
@@ -159,8 +159,10 @@
                 "  const _12 = Math.pow(_08, 2.0);\n"
                 "  const _13 = Math.pow(_09, 2.0);\n"
                 "  return [1.0, [y05 / A, (- y07 * _09 + y06) / (A * _12), (A * y07 * _12 + C * y07 * _13 - C * y06 * _09) / (A * C * _12)], [(A * gMR * Math.pow(_09, 4.0) - 2.0 * A * gMR * _13 - y06 * y07 * _13 + Math.pow(y06, 2.0) * _09 + Math.pow(y07, 2.0) * _09 + A * gMR - y06 * y07) / (A * Math.pow(_08, 3.0)), 0.0, 0.0]];"))]
-             (c/compile-state-fn* (fn [] sysder) [] top-state {:mode :js
-                                                              :gensym-fn (a/monotonic-symbol-generator 2)})))))
+             (c/compile-state-fn* (fn [] sysder) [] top-state
+               {:mode :js
+                :calling-convention :flat
+                :gensym-fn (a/monotonic-symbol-generator 2)})))))
 
   (deftest section-3-5
     (testing "p.221"


### PR DESCRIPTION
From the CHANGELOG:

- #115:

  This PR introduces significant upgrades to the functions in
  `emmy.expression.compile`. `compile-state-fn` and `compile-fn` now share the
  same code. Expect some more shifts here as we work on animations.

  Specifically, this update:

  - Removes timers from the code in `emmy.numerical.ode`. If you want timing
    data you can generate an derivative yourself that performs timing. Including
    this by default introduced a significant performance cost.

  - Renames `emmy.numerical.ode/integration-opts` to `make-integrator*`; it now
    returns only a call to `stream-integrator` instead of the old map of this
    result and timers.

  - In `emmy.expression.compile`:

    - `compile-state-fn*` and `compile-fn*` are now removed, in favor of the
      non-starred versions with option `:cache? false` supplied.

    - `compile-fn` now calls `compile-state-fn` with `params` set to `false` and
      an `:arity` option supplied, vs using its own mostly-duplicated
      implementation.

    - `:flatten?` option removed in favor of the more granular
      `:calling-convention`. This option supports values of `:structure`,
      `:flat` and `:primitive`. See the docstring for details.

    - `:mode` supports `:js`, `:source`, `:clj`, `:native` or `:sci`.