### PR TITLE
small ODE / compiler fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 ## [unreleased]
 
+- #119:
+
+  - Removes support for `:flat` compilation mode (this was a step toward
+    what is now called :primitive). Flat has no further use case.
+
+  - You can now "bring your own array" to the function provided by
+    `stream-integrator`, avoiding an allocation in performance-sensitive
+    contexts.
+
 - #118:
 
   - Fixes problems with the `resolve` calls in `emmy.util.def` triggered by

--- a/src/emmy/expression/compile.cljc
+++ b/src/emmy/expression/compile.cljc
@@ -253,14 +253,9 @@
   SICM. It maps a state tuple to its time derivative; structure in,
   structure out.
 
-  - `:flat => (fn [[t x0 x1 v0 v1] [p0 p1 ...]] ...)`
-
-  ODE solvers prefer to work with flat vectors, and so this calling
-  convention unrolls the state model into an ordered list of parameters.
-
   - `:primitive => (fn [ys yps ps])`
 
-  ODE solvers can gain yet more efficiency if they may allocate
+  ODE solvers can gain efficiency if they may allocate
   long-lived input and output vectors. Bindings for the individual
   state elements are inserted into the code's local variables.
   The input vector `ys` should have the same length as the flat
@@ -278,7 +273,6 @@
   (let [argv (case calling-convention
                :primitive (primitive-state-symbols #(gensym-fn "a"))
                :structure [(into [] state-model)]
-               :flat [(into [] (flatten state-model))]
                :native state-model
                (throw (ex-info "Invalid calling convention supplied"
                                {:calling-convention calling-convention})))]
@@ -546,13 +540,6 @@
 
         ```clojure
         (fn [[y1 [y2 y3] [y4 y5]]] [p1 ...] ...)
-        ```
-
-      - `:flat`: The compiled function will expect the state in flattened
-        form, which may be provided by any flat Clojure sequence:
-
-        ```clojure
-        (fn [[y1 y2 y3 y4 y5] [p1 ...]] ...)
         ```
 
       - `:primitive`: The compiled function will expect a primitive array

--- a/src/emmy/numerical/ode.cljc
+++ b/src/emmy/numerical/ode.cljc
@@ -83,8 +83,7 @@
           gbs
           (reify StepHandler
             (init [_ _ _ _])
-            (handleStep
-                [_ interpolator _]
+            (handleStep [_ interpolator _]
               ;; The `step-requests` channel sends `true` each time a new segment of
               ;; the solution is demanded; `false` is a signal that the consumer
               ;; has no further need of them. When sending segments back, receiving
@@ -150,18 +149,21 @@
                                 (when (u/throwable? v)
                                   (throw v))
                                 v))
-               current-segment (atom (next-segment))]
-           (fn
+               current-segment (atom (next-segment))
+               advance-segment (fn [x]
+                                 (when (< x (:x0 @current-segment))
+                                   (u/illegal-state "Cannot use interpolation function in backwards direction"))
+                                 (while (> x (:x1 @current-segment))
+                                   (let [s (next-segment)]
+                                     (reset! current-segment s)))
+                                 @current-segment)]
+           (fn f
              ([]
               (a/>!! step-requests false))
              ([x]
-              (when (< x (:x0 @current-segment))
-                (u/illegal-state "Cannot use interpolation function in backwards direction"))
-              (while (> x (:x1 @current-segment))
-                (let [s (next-segment)]
-                  (reset! current-segment s)))
-              (into [] ((:f @current-segment) x))))))
-
+              (into [] ((:f (advance-segment x)) x)))
+             ([x ^doubles out]
+              (System/arraycopy ((:f (advance-segment x)) x) 0 out 0 dimension)))))
        :cljs
        (let [solver (o/Solver.
                      f'

--- a/src/emmy/numerical/ode.cljc
+++ b/src/emmy/numerical/ode.cljc
@@ -150,20 +150,20 @@
                                   (throw v))
                                 v))
                current-segment (atom (next-segment))
-               advance-segment (fn [x]
+               evaluate-at (fn [x]
                                  (when (< x (:x0 @current-segment))
                                    (u/illegal-state "Cannot use interpolation function in backwards direction"))
                                  (while (> x (:x1 @current-segment))
                                    (let [s (next-segment)]
                                      (reset! current-segment s)))
-                                 @current-segment)]
+                                 ((:f @current-segment) x))]
            (fn f
              ([]
               (a/>!! step-requests false))
              ([x]
-              (into [] ((:f (advance-segment x)) x)))
+              (into [] (evaluate-at x)))
              ([x ^doubles out]
-              (System/arraycopy ((:f (advance-segment x)) x) 0 out 0 dimension)))))
+              (System/arraycopy (evaluate-at x) 0 out 0 dimension)))))
        :cljs
        (let [solver (o/Solver.
                      f'

--- a/test/emmy/examples/double_pendulum_test.cljc
+++ b/test/emmy/examples/double_pendulum_test.cljc
@@ -96,7 +96,7 @@
                             :deterministic? true})))
 
 
-  (is (= ["[y01, y02, y03, y04, y05]"
+  (is (= ["[y01, [y02, y03], [y04, y05]]"
           "[p06, p07, p08, p09, p10]"
           (maybe-defloatify
            (str
@@ -115,7 +115,6 @@
           '[1 1 1 1 'g]
           (up 't (up 'theta 'phi) (up 'thetadot 'phidot))
           {:mode :js
-           :calling-convention :flat
            :gensym-fn (a/monotonic-symbol-generator 2)
            :deterministic? true})))
 
@@ -130,7 +129,7 @@
     #?(:clj
        ;; even with the deterministic flag, this is not quite reproducing in
        ;; ClojureScript.
-       (is (= ["[y01, y02, y03, y04, y05]"
+       (is (= ["[y01, [y02, y03], [y04, y05]]"
                "_"
                (str
                 "  const _09 = - y03;\n"
@@ -165,6 +164,5 @@
                []
                (e/->H-state 't (up 'theta 'psi) (down 'p_theta 'p_psi))
                {:mode :js
-                :calling-convention :flat
                 :gensym-fn (a/monotonic-symbol-generator 2)
                 :deterministic? true}))))))

--- a/test/emmy/expression/compile_test.cljc
+++ b/test/emmy/expression/compile_test.cljc
@@ -42,8 +42,6 @@
                                                opts)))]
       (is (= `(fn [[~'y1 [~'y2 ~'y3] [~'y4 ~'y5]] [~'p6]] (* ~'p6 ~'y1))
              (compile {:mode :clj :calling-convention :structure})))
-      (is (= `(fn [[~'y1 ~'y2 ~'y3 ~'y4 ~'y5] [~'p6]] (* ~'p6 ~'y1))
-             (compile {:mode :clj :calling-convention :flat})))
       (is (= `(fn [~'a7 ~'a8 ~'a9]
                 (let [~'y1 (aget ~'a7 0)
                       ~'y2 (aget ~'a7 1)
@@ -55,8 +53,6 @@
              (compile {:mode :clj :calling-convention :primitive})))
       (is (= ["[y1, [y2, y3], [y4, y5]]" "[p6]" "  return p6 * y1;"]
              (compile {:mode :js :calling-convention :structure})))
-      (is (= ["[y1, y2, y3, y4, y5]" "[p6]" "  return p6 * y1;"]
-             (compile {:mode :js :calling-convention :flat})))
       (is (= ["a7"
               "a8"
               "a9"
@@ -279,13 +275,6 @@
       (is (= 10 (f t)))
       (is (= -4 ((sf 2) s)))
       (is (= 20 ((sf 2) t))))
-
-    (testing "compiled state function matches the original (flat)."
-      (let [cf (c/compile-state-fn sf [1] s {:calling-convention :flat})]
-        (is (v/= ((sf 1) s) (cf (flatten s) [1])))
-        (is (v/= ((sf 1) t) (cf (flatten t) [1])))
-        (is (v/= ((sf 2) s) (cf (flatten s) [2])))
-        (is (v/= ((sf 2) t) (cf (flatten t) [2])))))
 
     (testing "compiled state function matches the original (structure)."
       (let [cf (c/compile-state-fn sf [1] s {:calling-convention :structure})]

--- a/test/emmy/numerical/ode_test.cljc
+++ b/test/emmy/numerical/ode_test.cljc
@@ -46,6 +46,14 @@
           (is (near? (Math/exp x) ex))))
       (f)))
 
+  (testing "y' = y, new interface, BYO array"
+    (let [f (o/stream-integrator (fn [_ ^doubles y ^doubles out] (aset out 0 (aget y 0))) 0 [1] {:epsilon 1e-8})
+          a (double-array 1)]
+      (doseq [x (range 0 1 0.01)]
+        (f x a)
+        (is (near? (Math/exp x) (aget a 0))))
+      (f)))
+
   (testing "y'' = - y, new interface"
     (let [f (o/stream-integrator (fn [_ ^doubles y ^doubles out]
                                    (aset out 0 (aget y 1))
@@ -55,6 +63,18 @@
         (let [[c ms] (f x)]
           (is (near? (Math/cos x) c))
           (is (near? (- (Math/sin x)) ms))))
+      (f)))
+
+  (testing "y'' = - y, new interface, BYO array"
+    (let [f (o/stream-integrator (fn [_ ^doubles y ^doubles out]
+                                   (aset out 0 (aget y 1))
+                                   (aset out 1 (- (aget y 0))))
+                                 0 [1 0] {:epsilon 1e-8})
+          a (double-array 2)]
+      (doseq [x (range 0 (* 2 Math/PI) 0.1)]
+        (f x a)
+        (is (near? (Math/cos x) (aget a 0)))
+        (is (near? (- (Math/sin x)) (aget a 1))))
       (f)))
 
   (testing "stream integrator throws if used backwards"

--- a/test/emmy/sicm/ch3_test.cljc
+++ b/test/emmy/sicm/ch3_test.cljc
@@ -150,7 +150,7 @@
                           0))
                (simplify (sysder top-state)))))
 
-      (is (= ["[y01, y02, y03, y04, y05, y06, y07]"
+      (is (= ["[y01, [y02, y03, y04], [y05, y06, y07]]"
               "_"
               (maybe-defloatify
                (str
@@ -161,7 +161,6 @@
                 "  return [1.0, [y05 / A, (- y07 * _09 + y06) / (A * _12), (A * y07 * _12 + C * y07 * _13 - C * y06 * _09) / (A * C * _12)], [(A * gMR * Math.pow(_09, 4.0) - 2.0 * A * gMR * _13 - y06 * y07 * _13 + Math.pow(y06, 2.0) * _09 + Math.pow(y07, 2.0) * _09 + A * gMR - y06 * y07) / (A * Math.pow(_08, 3.0)), 0.0, 0.0]];"))]
              (c/compile-state-fn (fn [] sysder) [] top-state
                {:mode :js
-                :calling-convention :flat
                 :gensym-fn (a/monotonic-symbol-generator 2)})))))
 
   (deftest section-3-5


### PR DESCRIPTION
- remove :flat compilation mode (it was a step toward :primitive, but has no use case now)

- add ability to bring your own array to receive integrated points (odex-js supports this already, this brings parity to the JVM implementation)