### PR TITLE
Get template working before publish

### DIFF
--- a/resources/emmy/clerk/README.md
+++ b/resources/emmy/clerk/README.md
@@ -14,7 +14,7 @@ clojure -Ttools install io.github.seancorfield/deps-new '{:git/tag "v0.5.0"}' :a
 Then create a project using the `emmy/clerk` template:
 
 ```
-clojure -Sdeps '{:deps {io.github.mentat-collective/emmy {:git/tag "v0.30.0" :git/sha "TODO"}}}' \
+clojure -Sdeps '{:deps {io.github.mentat-collective/emmy {:git/sha "a6a79daebb82f95a7239e5ad0e8477ac8a27e539"}}}' \
 -Tnew create \
 :template emmy/clerk \
 :name myusername/my-emmy-project

--- a/resources/emmy/clerk/root/deps.edn
+++ b/resources/emmy/clerk/root/deps.edn
@@ -1,11 +1,11 @@
 {:paths ["src" "dev" "notebooks"]
  :deps {org.clojure/clojure {:mvn/version "{{clj-version}}"}
         io.github.nextjournal/clerk {:git/sha "{{clerk-sha}}"}
-        org.mentat/emmy {:mvn/version "{{emmy-version}}"
-                         ;; This is required because Clerk specifies SCI using a
-                         ;; git dependency and `clojure` can't resolve the
-                         ;; conflict.
-                         :exclusions [org.babashka/sci]}
+        io.github.mentat-collective/emmy {:git/sha "{{emmy-version}}"
+                                          ;; This is required because Clerk specifies SCI using a
+                                          ;; git dependency and `clojure` can't resolve the
+                                          ;; conflict.
+                                          :exclusions [org.babashka/sci]}
         io.github.mentat-collective/clerk-utils {:git/sha "{{clerk-utils-sha}}"}}
  :aliases
  {:nextjournal/clerk

--- a/resources/emmy/clerk/template.edn
+++ b/resources/emmy/clerk/template.edn
@@ -1,6 +1,6 @@
 {:description "TODO replace me with a description of your project!"
  :clerk-port 7777
- :emmy-version "0.30.0"
+ :emmy-version "a6a79daebb82f95a7239e5ad0e8477ac8a27e539"
  :clerk-sha "4329fa31b75bf26c04bdcc803a52fe642baec56e"
  :clerk-utils-sha "a508ab01d0fb04a44c0a6a1dd510207b2ca7135e"
  :shadow-port 8765


### PR DESCRIPTION
Switch to `git/sha` style so the template works before we publish a new version.