### PR TITLE
Implement Complex numbers natively in cljs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## [unreleased]
 
-- #XXX
+- #151
 
   - By porting `complex.js` to Clojure, we can remove the dependency on
     this library on the JavaScript side as well as the Apache Commons

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,10 +17,6 @@
     complex unit to a real power, but it only worked for integral r, and
     threw an exception in other cases; this special case is removed.
 
-    The string input form for complex numbers used to allow the form
-    "1 + -2i". We now insist on only a single sign between the real and
-    imaginary parts ("1-2i").
-
 - #149
 
   - Retires the Value protocol in favor of MultiFns in the generic scope.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,25 @@
 
 ## [unreleased]
 
+- #XXX
+
+  - By porting `complex.js` to Clojure, we can remove the dependency on
+    this library on the JavaScript side as well as the Apache Commons
+    complex implementation on the JVM side.
+
+    The JavaScript implementation is followed fairly closely and done with
+    generic Emmy arithmetic at the component level (except when that is
+    clearly unnecessary). The `(complex)` constructor has been made
+    equivalent to the reader parser.
+
+    The former implementation made a special case of i^r, raising the
+    complex unit to a real power, but it only worked for integral r, and
+    threw an exception in other cases; this special case is removed.
+
+    The string input form for complex numbers used to allow the form
+    "1 + -2i". We now insist on only a single sign between the real and
+    imaginary parts ("1-2i").
+
 - #149
 
   - Retires the Value protocol in favor of MultiFns in the generic scope.

--- a/package.json
+++ b/package.json
@@ -23,7 +23,6 @@
     "@lezer/markdown": "1.0.2",
     "@nextjournal/lang-clojure": "1.0.0",
     "@nextjournal/lezer-clojure": "1.0.0",
-    "complex.js": "^2.1.1",
     "d3-require": "1.3.0",
     "fraction.js": "4.2.1",
     "framer-motion": "6.5.1",

--- a/src/deps.cljs
+++ b/src/deps.cljs
@@ -1,4 +1,3 @@
 {:npm-deps
- {"complex.js" "^2.1.1"
-  "fraction.js" "4.2.1"
+ {"fraction.js" "4.2.1"
   "odex" "3.0.0-rc.4"}}

--- a/src/emmy/complex.cljc
+++ b/src/emmy/complex.cljc
@@ -106,12 +106,12 @@
   or (* -1 z)), whichever number has a positive real component."
   [z]
   (cond (complex? z)
-        (if (neg? (real z))
+        (if (g/negative? (real z))
           (g/negate z)
           z)
 
         (v/real? z)
-        (Math/abs ^double (u/double z))
+        (g/abs z)
 
         :else (u/illegal "not supported!")))
 
@@ -154,9 +154,9 @@
 (defmethod g/one? [::complex] [c] (and (g/one? (real c))
                                        (g/zero? (imaginary c))))
 (defmethod g/identity? [::complex] [c] (g/one? c))
-(defmethod g/zero-like [::complex] [_] ZERO)
-(defmethod g/one-like [::complex] [_] ONE)
-(defmethod g/identity-like [::complex] [_] ONE)
+(defmethod g/zero-like [::complex] [c] (c/zero-like c))
+(defmethod g/one-like [::complex] [c] (c/one-like c))
+(defmethod g/identity-like [::complex] [c] (c/one-like c))
 (defmethod g/freeze [::complex] [c]
   (let [re (real c)
         im (imaginary c)]
@@ -195,16 +195,16 @@
 
 (defmethod v/= [::complex ::complex] [a b] (c/equal? a b))
 (defmethod v/= [::complex ::v/real] [a n]
-  (and (zero? (imaginary a))
+  (and (g/zero? (imaginary a))
        (v/= (real a) n)))
 
 (defmethod v/= [::v/real ::complex] [n a]
-  (and (zero? (imaginary a))
+  (and (g/zero? (imaginary a))
        (v/= n (real a))))
 
 (defmethod g/add [::complex ::complex] [a b] (c/add a b))
 ;; XXX consider making these methods in impl to avoid an allocation
-(defmethod g/add [::complex ::v/real] [a n] (c/add a (complex n)))
+(defmethod g/add [::complex ::v/real] [a n] (c/add a (complex n)))x
 (defmethod g/add [::v/real ::complex] [n a] (c/add (complex n) a))
 
 (defmethod g/sub [::complex ::complex] [a b] (c/sub a b))

--- a/src/emmy/complex.cljc
+++ b/src/emmy/complex.cljc
@@ -62,14 +62,6 @@
   [z]
   (c/imaginary z))
 
-;; ## Type Extensions
-
-#?(:clj
-   (defmethod print-method emmy.complex.impl.Complex [v ^java.io.Writer w]
-     (.write w (str "#emmy/complex "
-                    [(c/real v)
-                     (c/imaginary v)]))))
-
 ;; ## Gaussian Integers
 
 (defn round

--- a/src/emmy/complex.cljc
+++ b/src/emmy/complex.cljc
@@ -12,9 +12,6 @@
             [emmy.util :as u]
             [emmy.value :as v]))
 
-(extend-type emmy.complex.impl.Complex
- )
-
 (def ZERO
   "A [[Complex]] value equal to 0 (south pole on the Riemann Sphere)."
   c/ZERO)
@@ -46,11 +43,11 @@
    (c/->Complex re im)))
 
 (defn parse-complex
-  [& args]
   "Used as a [data reader](https://www.clojurescript.org/guides/reader#_clojurescript_compilation).
-   In Clojure, we could get away with just using the constructor above, but in
-   ClojureScript we need to act as a macro to delay evaluation of the constructor."
-  `(complex ~@args))
+  In Clojure, we could get away with just using the constructor above, but in
+  ClojureScript we need to act as a macro to delay evaluation of the constructor."
+  [c]
+  `(complex ~c))
 
 (defn complex?
   "Returns true if `a` is an instance of [[Complex]], false otherwise."
@@ -240,13 +237,20 @@
 (defmethod g/cos [::complex] [z] (c/cos z))
 (defmethod g/tan [::complex] [z] (c/tan z))
 (defmethod g/sec [::complex] [z] (c/sec z))
+(defmethod g/csc [::complex] [z] (c/csc z))
 (defmethod g/cot [::complex] [z] (c/cot z))
 
 (defmethod g/asin [::complex] [z] (c/asin z))
 (defmethod g/acos [::complex] [z] (c/acos z))
 (defmethod g/atan [::complex] [z] (c/atan z))
+(defmethod g/acsc [::complex] [z] (c/acsc z))
+(defmethod g/asec [::complex] [z] (c/asec z))
+(defmethod g/acot [::complex] [z] (c/acot z))
 
+(defmethod g/asinh [::complex] [z] (c/asinh z))
 (defmethod g/acosh [::complex] [z] (c/acosh z))
+(defmethod g/asech [::complex] [z] (c/asech z))
+(defmethod g/acsch [::complex] [z] (c/acsch z))
 
 (defmethod g/floor [::complex] [z] (c/floor z))
 (defmethod g/ceiling [::complex] [z] (c/ceil z))
@@ -254,6 +258,8 @@
 (defmethod g/cosh [::complex] [z] (c/cosh z))
 (defmethod g/sinh [::complex] [z] (c/sinh z))
 (defmethod g/tanh [::complex] [z] (c/tanh z))
+(defmethod g/sech [::complex] [z] (c/sech z))
+(defmethod g/csch [::complex] [z] (c/csch z))
 (defmethod g/coth [::complex] [z] (c/coth z))
 
 (defmethod g/integer-part [::complex] [a]

--- a/src/emmy/complex.cljc
+++ b/src/emmy/complex.cljc
@@ -249,8 +249,10 @@
 
 (defmethod g/asinh [::complex] [z] (c/asinh z))
 (defmethod g/acosh [::complex] [z] (c/acosh z))
+(defmethod g/atanh [::complex] [z] (c/atanh z))
 (defmethod g/asech [::complex] [z] (c/asech z))
 (defmethod g/acsch [::complex] [z] (c/acsch z))
+(defmethod g/acoth [::complex] [z] (c/acoth z))
 
 (defmethod g/floor [::complex] [z] (c/floor z))
 (defmethod g/ceiling [::complex] [z] (c/ceil z))

--- a/src/emmy/complex.cljc
+++ b/src/emmy/complex.cljc
@@ -120,7 +120,6 @@
                             [l r] [r l])]
                 (loop [a l
                        b r]
-                  (println "gcd" a b (if (g/zero? b) "done" [(g/div a b) (round (g/div a b))]))
                   (if (g/zero? b)
                     (abs-real a)
                     (recur b (g/sub a (g/mul (round (g/div a b)) b))))))))

--- a/src/emmy/complex/impl.cljc
+++ b/src/emmy/complex/impl.cljc
@@ -1,3 +1,5 @@
+#_"SPDX-License-Identifier: GPL-3.0"
+
 ;; /**
 ;;  * @license Complex.js v2.1.1 12/05/2020
 ;;  *
@@ -6,846 +8,487 @@
 ;;  **/
 
 (ns emmy.complex.impl
-  (:refer-clojure :exclude [abs]))
+  "This namespace provides the primitive implementation of complex
+   arithmetic for Emmy. The authors are indebted to Robert Eisele's
+   `Complex.js` implementation from which we have borrowed freely and
+   which is licensed as follows:
 
-(deftype Complex [re im])
+   * Copyright (c) 2020, Robert Eisele (robert@xarg.org)
+   * Dual licensed under the MIT or GPL Version 2 licenses."
+  (:refer-clojure :exclude [abs zero?])
+  (:require [emmy.generic :as g]
+            [emmy.util :as u]
+            [emmy.value :as v]))
+
+(declare equal?)
+
+(deftype Complex [re im]
+  v/IKind
+  (kind [_] :emmy.complex/complex)
+
+  v/Numerical
+  (numerical? [_] true)
+
+  #?@(:clj [Object
+            (equals [a b] (equal? a b))]
+      :cljs [IEquiv
+             (-equiv [a b] (equal? a b))
+
+             IPrintWithWriter
+             (-pr-writer
+              [z writer _]
+              (write-all
+               writer
+               "#emmy/complex "
+               (str [(.-re z) (.-im z)])))]))
 
 (def ZERO (Complex. 0 0))
 (def ONE (Complex. 1 0))
 (def I (Complex. 0 1))
+(def -I (Complex. 0 -1))
 (def PI (Complex. Math/PI 0))
 (def E (Complex. Math/E 0))
 (def INFINITY (Complex. ##Inf ##Inf))
+(def NAN (Complex. ##NaN ##NaN))
+(def LN2 (Math/log 2))
 
-(def NAN
-  #?(:cljs (Complex. js/NaN js/NaN)
-     :clj  (Complex. Double/NaN Double/NaN)))
+(def ^:private PI:4 (/ Math/PI 4))
 
-(def EPSILON 1e-15)
+(defn equal?
+  "Test for complex equality with another object."
+  [^Complex a b]
+  (and (instance? Complex b)
+       (v/= (.-re a) (.-re b))
+       (v/= (.-im a) (.-im b))))
 
-;; /**
-;;  *
-;;  * This class allows the manipulation of complex numbers.
-;;  * You can pass a complex number in different formats. Either as object, double, string or two integer parameters.
-;;  *
-;;  * Object form
-;;  * { re: <real>, im: <imaginary> }
-;;  * { arg: <angle>, abs: <radius> }
-;;  * { phi: <angle>, r: <radius> }
-;;  *
-;;  * Array / Vector form
-;;  * [ real, imaginary ]
-;;  *
-;;  * Double form
-;;  * 99.3 - Single double value
-;;  *
-;;  * String form
-;;  * '23.1337' - Simple real number
-;;  * '15+3i' - a simple complex number
-;;  * '3-i' - a simple complex number
-;;  *
-;;  * Example:
-;;  *
-;;  * var c = new Complex('99.3+8i');
-;;  * c.mul({r: 3, i: 9}).div(4.9).sub(3, 2);
-;;  *
-;;  */
+(defn zero?
+  "Determines whether or not a complex number is at the zero pole of the
+  Riemann sphere."
+  [^Complex z]
+  (and (g/zero? (.-re z))
+       (g/zero? (.-im z))))
 
-(defn cos-1 [x])
-;;   /**
-;;    * Calculates cos(x) - 1 using Taylor series if x is small (-¼π ≤ x ≤ ¼π).
-;;    *
-;;    * @param {number} x
-;;    * @returns {number} cos(x) - 1
-;;    */
-;;   var cosm1 = function(x) {
+(defn nan?
+  "Determines whether a complex number is not on the Riemann sphere."
+  [^Complex z]
+  (or (u/nan? (.-re z))
+      (u/nan? (.-im z))))
 
-;;     var b = Math.PI / 4;
-;;     if (-b > x || x > b) {
-;;       return Math.cos(x) - 1.0;
-;;     }
+(defn finite?
+  "Determines whether a complex number is not at the infinity pole of the
+    Riemann sphere."
+  [z]
+  (and (u/finite? (.-re z))
+       (u/finite? (.-im z))))
 
-;;     /* Calculate horner form of polynomial of taylor series in Q
-;;     var fac = 1, alt = 1, pol = {};
-;;     for (var i = 0; i <= 16; i++) {
-;;       fac*= i || 1;
-;;       if (i % 2 == 0) {
-;;         pol[i] = new Fraction(1, alt * fac);
-;;         alt = -alt;
-;;       }
-;;     }
-;;     console.log(new Polynomial(pol).toHorner()); // (((((((1/20922789888000x^2-1/87178291200)x^2+1/479001600)x^2-1/3628800)x^2+1/40320)x^2-1/720)x^2+1/24)x^2-1/2)x^2+1
-;;     */
+(defn infinite?
+  "Determines whether or not a complex number is at the infinity pole of the Riemann sphere."
+  [z]
+  (not
+   (or (nan? z) (finite? z))))
 
-;;     var xx = x * x;
-;;     return xx * (
-;;       xx * (
-;;         xx * (
-;;           xx * (
-;;             xx * (
-;;               xx * (
-;;                 xx * (
-;;                   xx / 20922789888000
-;;                   - 1 / 87178291200)
-;;                 + 1 / 479001600)
-;;               - 1 / 3628800)
-;;             + 1 / 40320)
-;;           - 1 / 720)
-;;         + 1 / 24)
-;;       - 1 / 2);
-;;   };
+(comment
+  (require '[emmy.series :as s])
+  (take 10 (g/- s/cos-series 1))
+  ;; => (0 0 -1/2 0 1/24 0 -1/720 0 1/40320 0)
+  ;; From this we can see that we may regard the expansion as a series in x^2, with a
+  ;; zero constant term.
+  (->> (g/- s/cos-series 1)
+       (remove g/zero?)  ;; eliminate the useless zero coefficients of the odd powers of x
+       (map double)      ;; we don't want the rational arithmetic to survive
+       (take 8)          ;; the filtered series now has coefficients for x^2, x^4 ... x^16
+       (cons 0.)         ;; cons 0 and reverse facilitate evaluation with Horner's method
+       (reverse))
+  ;; => (4.779477332387385E-14 -1.147074559772972E-11 2.08767569878681E-9 -2.755731922398589E-7
+  ;;     2.48015873015873E-5 -0.001388888888888889 0.04166666666666667 -0.5 0.0)
+  ;; We copy this sequence, in order to avoid the dependency complex -> series,
+  ;; which creates a cycle that would be difficult to break, and it's clear in
+  ;; this case that complex is lower in the abstraction hierarchy than series.
+  )
 
-(defn hypot [x y])
+(def ^:private cos-1-square-terms
+  [4.779477332387385E-14 -1.147074559772972E-11 2.08767569878681E-9 -2.755731922398589E-7
+   2.48015873015873E-5 -0.001388888888888889 0.04166666666666667 -0.5 0.0])
 
-;;   var hypot = function(x, y) {
+(defn cos-1
+  "Computes $\\cos(x)-1$ using Taylor series if $|x|\\le{\\pi\\over 4}$),
+   otherwise just subtracts one from `(Math/cos x)`. Doing the latter
+   when x is small squanders significant digits."
+  [x]
+  (cond (g/zero? x) (g/zero-like x)
+        (> (g/abs x) PI:4) (- (Math/cos x) 1)
+        :else
+        (let [xx (* x x)]
+          (reduce (fn [a b] (+ (* a xx) b)) cos-1-square-terms))))
 
-;;     var a = Math.abs(x);
-;;     var b = Math.abs(y);
+(defn real
+  [^Complex z]
+  (.-re z))
 
-;;     if (a < 3000 && b < 3000) {
-;;       return Math.sqrt(a * a + b * b);
-;;     }
-
-;;     if (a < b) {
-;;       a = b;
-;;       b = x / y;
-;;     } else {
-;;       b = y / x;
-;;     }
-;;     return a * Math.sqrt(1 + b * b);
-;;   };
-
-;;   var parser_exit = function() {
-;;     throw SyntaxError('Invalid Param');
-;;   };
-
-(defn log-hypot [x])
-
-;;   /**
-;;    * Calculates log(sqrt(a^2+b^2)) in a way to avoid overflows
-;;    *
-;;    * @param {number} a
-;;    * @param {number} b
-;;    * @returns {number}
-;;    */
-;;   function logHypot(a, b) {
-
-;;     var _a = Math.abs(a);
-;;     var _b = Math.abs(b);
-
-;;     if (a === 0) {
-;;       return Math.log(_b);
-;;     }
-
-;;     if (b === 0) {
-;;       return Math.log(_a);
-;;     }
-
-;;     if (_a < 3000 && _b < 3000) {
-;;       return Math.log(a * a + b * b) * 0.5;
-;;     }
-
-;;     /* I got 4 ideas to compute this property without overflow:
-;;      *
-;;      * Testing 1000000 times with random samples for a,b ∈ [1, 1000000000] against a big decimal library to get an error estimate
-;;      *
-;;      * 1. Only eliminate the square root: (OVERALL ERROR: 3.9122483030951116e-11)
-
-;;      Math.log(a * a + b * b) / 2
-
-;;      *
-;;      *
-;;      * 2. Try to use the non-overflowing pythagoras: (OVERALL ERROR: 8.889760039210159e-10)
-
-;;      var fn = function(a, b) {
-;;      a = Math.abs(a);
-;;      b = Math.abs(b);
-;;      var t = Math.min(a, b);
-;;      a = Math.max(a, b);
-;;      t = t / a;
-
-;;      return Math.log(a) + Math.log(1 + t * t) / 2;
-;;      };
-
-;;      * 3. Abuse the identity cos(atan(y/x) = x / sqrt(x^2+y^2): (OVERALL ERROR: 3.4780178737037204e-10)
-
-;;      Math.log(a / Math.cos(Math.atan2(b, a)))
-
-;;      * 4. Use 3. and apply log rules: (OVERALL ERROR: 1.2014087502620896e-9)
-
-;;      Math.log(a) - Math.log(Math.cos(Math.atan2(b, a)))
-
-;;      */
-
-;;      a = a / 2;
-;;      b = b / 2;
-
-;;     return 0.5 * Math.log(a * a + b * b) + Math.LN2;
-;;   }
-
-(defn parse [a b])
-
-;;   var parse = function(a, b) {
-
-;;     var z = { 're': 0, 'im': 0 };
-
-;;     if (a === undefined || a === null) {
-;;       z['re'] =
-;;       z['im'] = 0;
-;;     } else if (b !== undefined) {
-;;       z['re'] = a;
-;;       z['im'] = b;
-;;     } else
-;;       switch (typeof a) {
-
-;;         case 'object':
-
-;;           if ('im' in a && 're' in a) {
-;;             z['re'] = a['re'];
-;;             z['im'] = a['im'];
-;;           } else if ('abs' in a && 'arg' in a) {
-;;             if (!Number.isFinite(a['abs']) && Number.isFinite(a['arg'])) {
-;;               return Complex['INFINITY'];
-;;             }
-;;             z['re'] = a['abs'] * Math.cos(a['arg']);
-;;             z['im'] = a['abs'] * Math.sin(a['arg']);
-;;           } else if ('r' in a && 'phi' in a) {
-;;             if (!Number.isFinite(a['r']) && Number.isFinite(a['phi'])) {
-;;               return Complex['INFINITY'];
-;;             }
-;;             z['re'] = a['r'] * Math.cos(a['phi']);
-;;             z['im'] = a['r'] * Math.sin(a['phi']);
-;;           } else if (a.length === 2) { // Quick array check
-;;             z['re'] = a[0];
-;;             z['im'] = a[1];
-;;           } else {
-;;             parser_exit();
-;;           }
-;;           break;
-
-;;         case 'string':
-
-;;           z['im'] = /* void */
-;;           z['re'] = 0;
-
-;;           var tokens = a.match(/\d+\.?\d*e[+-]?\d+|\d+\.?\d*|\.\d+|./g);
-;;           var plus = 1;
-;;           var minus = 0;
-
-;;           if (tokens === null) {
-;;             parser_exit();
-;;           }
-
-;;           for (var i = 0; i < tokens.length; i++) {
-
-;;             var c = tokens[i];
-
-;;             if (c === ' ' || c === '\t' || c === '\n') {
-;;               /* void */
-;;             } else if (c === '+') {
-;;               plus++;
-;;             } else if (c === '-') {
-;;               minus++;
-;;             } else if (c === 'i' || c === 'I') {
-
-;;               if (plus + minus === 0) {
-;;                 parser_exit();
-;;               }
-
-;;               if (tokens[i + 1] !== ' ' && !isNaN(tokens[i + 1])) {
-;;                 z['im'] += parseFloat((minus % 2 ? '-' : '') + tokens[i + 1]);
-;;                 i++;
-;;               } else {
-;;                 z['im'] += parseFloat((minus % 2 ? '-' : '') + '1');
-;;               }
-;;               plus = minus = 0;
-
-;;             } else {
-
-;;               if (plus + minus === 0 || isNaN(c)) {
-;;                 parser_exit();
-;;               }
-
-;;               if (tokens[i + 1] === 'i' || tokens[i + 1] === 'I') {
-;;                 z['im'] += parseFloat((minus % 2 ? '-' : '') + c);
-;;                 i++;
-;;               } else {
-;;                 z['re'] += parseFloat((minus % 2 ? '-' : '') + c);
-;;               }
-;;               plus = minus = 0;
-;;             }
-;;           }
-
-;;           // Still something on the stack
-;;           if (plus + minus > 0) {
-;;             parser_exit();
-;;           }
-;;           break;
-
-;;         case 'number':
-;;           z['im'] = 0;
-;;           z['re'] = a;
-;;           break;
-
-;;         default:
-;;           parser_exit();
-;;       }
-
-;;     if (isNaN(z['re']) || isNaN(z['im'])) {
-;;       // If a calculation is NaN, we treat it as NaN and don't throw
-;;       //parser_exit();
-;;     }
-
-;;     return z;
-;;   };
-
-(deftype Complex [re im])
-
-(defn build [a b]
-  (->Complex a b))
-
-;;   /**
-;;    * @constructor
-;;    * @returns {Complex}
-;;    */
-;;   function Complex(a, b) {
-
-;;     if (!(this instanceof Complex)) {
-;;       return new Complex(a, b);
-;;     }
-
-;;     var z = parse(a, b);
-
-;;     this['re'] = z['re'];
-;;     this['im'] = z['im'];
-;;   }
-
-;;   Complex.prototype = {
-
-;;     're': 0,
-;;     'im': 0,
+(defn imaginary
+  [^Complex z]
+  (.-im z))
 
 (defn abs
   "Calculate the magnitude of the complex number"
   [^Complex z]
-  (hypot (.-re z) (.-im z)))
+  (let [x (.-re z)
+        y (.-im z)
+        a (g/abs x)
+        b (g/abs y)]
+    (cond (and (< a 3000) (< b 3000))
+          (g/sqrt (g/+ (g/* a a) (g/* b b)))
+
+          (< a b)
+          (g/* b (g/sqrt (g/+ 1 (g/expt (g// x y) 2))))
+
+          :else
+          (g/* a (g/sqrt (g/+ 1 (g/expt (g// y x) 2)))))))
+
+(defn log-hypot
+  "Calculates log(sqrt(a^2+b^2)) in a way to avoid overflows"
+  ([^Complex z]
+   (log-hypot (.-re z) (.-im z)))
+  ([a b]
+   (let [_a (g/abs a)
+         _b (g/abs b)]
+     (cond (g/zero? a) (g/log _b)
+           (g/zero? b) (g/log _a)
+           (and (< _a 3000)
+                (< _b 3000)) (g// (g/log (g/+ (g/* a a) (g/* b b))) 2)
+           :else (let [a (g// a 2)
+                       b (g// b 2)]
+                   (g/+ LN2 (g/* 0.5 (Math/log (g/+ (g/* a a) (g/* b b))))))))))
+
+(comment
+
+  (def c-re #"([+-]?\d+(\.\d*)?)(\s?([+-])\s?(\d+(\.\d*)?)[Ii])?")
+  (def c-re #"([+-]?\d+(\.\d*)?([Ee][+-]?\d+)?)(\s?([+-])\s?(\d+(\.\d*)?([Ee][+-]?\d+)?)[Ii])?")
+
+
+
+  (re-matches c-re "+1.0e0+2.2e-03i")
+  (re-matches c-re "1e2")
+  (re-matches c-re "1+2i")
+  (def m (re-matches c-re))
+  (m "3.14")
+  )
+
+(let [complex-re #"([+-]?\d+(\.\d*)?([Ee][+-]?\d+)?)(\s?([+-])\s?(\d+(\.\d*)?([Ee][+-]?\d+)?)[Ii])?"]
+  (defn parse
+    "Parse a complex number. We expect one or two floating point numbers.
+    If two, they must be separated by a sign (perhaps surrounded by at most
+    one space, the second number followed by I or i. Example: 1.2-3.4i)"
+    [s]
+    (if-let [[_ re re-frac re-expt _ sign im im-frac im-expt] (re-matches complex-re s)]
+      (->Complex ((if (or re-frac re-expt) u/parse-double u/parse-int) re)
+                 (* (if (= sign "-") -1 1)
+                    (if im ((if (or im-frac im-expt) u/parse-double u/parse-int) im) 0)))
+      (throw (ex-info "invalid complex number" {:input s})))))
+
+(comment
+  (parse "1+2i")
+
+  (parse "1.1-3.2i")
+
+  (parse "-1.1-2.3I")
+
+  (parse "foo")
+  )
 
 (defn sign
   "Calculates the sign of a complex number, which is a normalized complex"
   [z]
   (let [abs-z (abs z)]
-    (build
+    (->Complex
      (/ (.-re z) abs-z)
      (/ (.-im z) abs-z))))
 
-(defn add [l r])
-;;     /**
-;;      * Adds two complex numbers
-;;      *
-;;      * @returns {Complex}
-;;      */
-;;     'add': function(a, b) {
+(defn add
+  "Compute the complex sum."
+  [^Complex l ^Complex r]
+  (->Complex (g/+ (.-re l) (.-re r))
+             (g/+ (.-im l) (.-im r))))
 
-;;       var z = new Complex(a, b);
+(defn sub
+  "Compute the complex difference."
+  [^Complex l ^Complex r]
+  (->Complex (g/- (.-re l) (.-re r))
+             (g/- (.-im l) (.-im r))))
 
-;;       // Infinity + Infinity = NaN
-;;       if (this['isInfinite']() && z['isInfinite']()) {
-;;         return Complex['NAN'];
-;;       }
+(defn mul
+  "Compute the complex product."
+  [^Complex l ^Complex r]
+  (cond (or (and (infinite? l) (zero? r))
+            (and (zero? l) (infinite? r)))
+        NAN
 
-;;       // Infinity + z = Infinity { where z != Infinity }
-;;       if (this['isInfinite']() || z['isInfinite']()) {
-;;         return Complex['INFINITY'];
-;;       }
+        (or (infinite? l) (infinite? r))
+        INFINITY  ;; NB: some libraries are more careful with the sign of infinity than this one
 
-;;       return new Complex(
-;;         this['re'] + z['re'],
-;;         this['im'] + z['im']);
-;;     },
+        :else (let [a (.-re l)
+                    b (.-im l)
+                    c (.-re r)
+                    d (.-im r)]
+                (if (and (g/zero? b) (g/zero? d))
+                  (g/* a c)
+                  (->Complex (g/- (g/* a c) (g/* b d))
+                             (g/+ (g/* a d) (g/* b c)))))))
 
-(defn sub [l r])
-;;     /**
-;;      * Subtracts two complex numbers
-;;      *
-;;      * @returns {Complex}
-;;      */
-;;     'sub': function(a, b) {
+(defn div
+  "Compute the complex quotient."
+  [^Complex l ^Complex r]
+  (cond (or (and (zero? l) (zero? r))
+            (and (infinite? l) (infinite? r)))
+        NAN
 
-;;       var z = new Complex(a, b);
+        (or (infinite? l) (zero? r))
+        INFINITY
 
-;;       // Infinity - Infinity = NaN
-;;       if (this['isInfinite']() && z['isInfinite']()) {
-;;         return Complex['NAN'];
-;;       }
+        (or (zero? l) (infinite? r))
+        ZERO
 
-;;       // Infinity - z = Infinity { where z != Infinity }
-;;       if (this['isInfinite']() || z['isInfinite']()) {
-;;         return Complex['INFINITY'];
-;;       }
+        :else
+        (let [a (.-re l)
+              b (.-im l)
+              c (.-re r)
+              d (.-im r)]
+          (cond (g/zero? d)
+                (->Complex (g// a c) (g// b c))
 
-;;       return new Complex(
-;;         this['re'] - z['re'],
-;;         this['im'] - z['im']);
-;;     },
+                (< (g/abs c) (g/abs d))
+                (let [x (g// c d)
+                      t (g/+ (g/* c x) d)]
+                  (->Complex (g// (g/+ (g/* a x) b) t)
+                             (g// (g/- (g/* b x) a) t)))
 
-(defn mul [l r])
-;;     /**
-;;      * Multiplies two complex numbers
-;;      *
-;;      * @returns {Complex}
-;;      */
-;;     'mul': function(a, b) {
+                :else
+                (let [x (g// d c)
+                      t (g/+ (g/* d x) c)]
+                  (->Complex (g// (g/+ a (g/* b x)) t)
+                             (g// (g/- b (g/* a x)) t)))))))
 
-;;       var z = new Complex(a, b);
 
-;;       // Infinity * 0 = NaN
-;;       if ((this['isInfinite']() && z['isZero']()) || (this['isZero']() && z['isInfinite']())) {
-;;         return Complex['NAN'];
-;;       }
+(defn pow
+  "Calculate the power of two complex numbers."
+  [^Complex l ^Complex r]
+  (letfn [(power [a b c d]
+            ;; I couldn't find a good formula, so here is a derivation and optimization
+            ;;
+            ;; z_1^z_2 = (a + bi)^(c + di)
+            ;;         = exp((c + di) * log(a + bi)
+            ;;         = pow(a^2 + b^2, (c + di) / 2) * exp(i(c + di)atan2(b, a))
+            ;; =>...
+            ;; Re = (pow(a^2 + b^2, c / 2) * exp(-d * atan2(b, a))) * cos(d * log(a^2 + b^2) / 2 + c * atan2(b, a))
+            ;; Im = (pow(a^2 + b^2, c / 2) * exp(-d * atan2(b, a))) * sin(d * log(a^2 + b^2) / 2 + c * atan2(b, a))
+            ;;
+            ;; =>...
+            ;; Re = exp(c * log(sqrt(a^2 + b^2)) - d * atan2(b, a)) * cos(d * log(sqrt(a^2 + b^2)) + c * atan2(b, a))
+            ;; Im = exp(c * log(sqrt(a^2 + b^2)) - d * atan2(b, a)) * sin(d * log(sqrt(a^2 + b^2)) + c * atan2(b, a))
+            ;;
+            ;; =>
+            ;; Re = exp(c * logsq2 - d * arg(z_1)) * cos(d * logsq2 + c * arg(z_1))
+            ;; Im = exp(c * logsq2 - d * arg(z_1)) * sin(d * logsq2 + c * arg(z_1))
+            (if (and (g/zero? a)
+                     (g/zero? b)
+                     (not (or (g/zero? c) (g/negative? c)))
+                     (not (g/negative? d)))
+              ZERO
+              (let [arg (g/atan b a)
+                    loh (log-hypot a b)
+                    e (g/exp (g/- (g/* c loh) (g/* d arg)))
+                    f (g/+ (g/* d loh) (g/* c arg))]
+                (->Complex (g/* e (g/cos f))
+                           (g/* e (g/sin f))))))]
+    (if (g/zero? r)
+      ;; Mathematica considers 0^0 indeterminate. Knuth argues that ONE is correct here.
+      ;; Complex.js returns ONE in this case, and since there is some support for this
+      ;; position we will continue to do so.
+      ONE
+      (let [a (.-re l)
+            b (.-im l)
+            c (.-re r)
+            d (.-im r)]
+        (cond (g/zero? d)
+              ;; exponent is real
+              (cond (g/zero? b)
+                    ;; Note 1: complex.js conditioned this branch on `b === 0 && a > 0`.
+                    ;; The case where a === 0 as well was handled above, wherein 0^z == 1
+                    ;; for all z. There seems to be no reason to not handle the case
+                    ;; b == 0, a < 0, d == 0 here as well as the a > 0 case (i.e., we expect
+                    ;; the underlying g/expt function to work just fine with negative bases
+                    ;; in the purely real case).
 
-;;       // Infinity * z = Infinity { where z != 0 }
-;;       if (this['isInfinite']() || z['isInfinite']()) {
-;;         return Complex['INFINITY'];
-;;       }
+                    ;; Note 2: Should we "lower to real" in cases like this? How about in
+                    ;; general cases like addition? Previously, complex has been treated,
+                    ;; like floating point, as an absorptive arithmetic trap: once entered,
+                    ;; you can't escape without help. But if we regard complex as an ordered
+                    ;; pair of emmy objects with special multiplication and division, it might
+                    ;; make more sense to lower results that live on the real line.
+                    (->Complex (g/expt a, c) 0)
 
-;;       // Short circuit for real values
-;;       if (z['im'] === 0 && this['im'] === 0) {
-;;         return new Complex(this['re'] * z['re'], 0);
-;;       }
+                    (and (g/zero? a)
+                         (g/one? b)
+                         (v/integral? c))
+                    (nth [1 I -1 (g/negate I)] (mod c 4))
 
-;;       return new Complex(
-;;         this['re'] * z['re'] - this['im'] * z['im'],
-;;         this['re'] * z['im'] + this['im'] * z['re']);
-;;     },
+                    :else
+                    (power a b c d))
 
-(defn div [l r])
-;;     /**
-;;      * Divides two complex numbers
-;;      *
-;;      * @returns {Complex}
-;;      */
-;;     'div': function(a, b) {
+              ;; if we continue to nevermind about the i^r case we can simplify the cond
+              :else
+              (power a b c d))))))
 
-;;       var z = new Complex(a, b);
+(defn sqrt
+  "Calculate the complex square root"
+  [^Complex z]
+  (let [a (.-re z)
+        age0 (>= a 0)
+        b (.-im z)]
+    (if (and (g/zero? b)
+             age0)
+      (->Complex (g/sqrt a) 0)
+      (let [r (abs z)
+            re (if age0
+                 (* 0.5 (Math/sqrt (* 2 (+ r a))))
+                 (/ (Math/abs b) (Math/sqrt (* 2 (- r a)))))
+            im (if age0
+                 (/ (Math/abs b) (Math/sqrt (* 2 (+ r a))))
+                 (* 0.5 (Math/sqrt (* 2 (- r a)))))]
+        (->Complex re (if (< b 0) (- im) im))))))
 
-;;       // 0 / 0 = NaN and Infinity / Infinity = NaN
-;;       if ((this['isZero']() && z['isZero']()) || (this['isInfinite']() && z['isInfinite']())) {
-;;         return Complex['NAN'];
-;;       }
+(defn exp
+  "Calculate the complex exponential"
+  [^Complex z]
+  (let [ea (g/exp (.-re z))
+        b (.-im z)]
+    (->Complex (g/* ea (g/cos b)) (g/* ea (g/sin b)))))
 
-;;       // Infinity / 0 = Infinity
-;;       if (this['isInfinite']() || z['isZero']()) {
-;;         return Complex['INFINITY'];
-;;       }
+(defn exp-1
+  "Calculate the complex exponent and subtracts one.
+  This may be more accurate than `(- (exp z) 1)` if
+  `z` is small."
+  [^Complex z]
+  ;;   exp(a + i*b) - 1
+  ;; = exp(a) * (cos(b) + j*sin(b)) - 1
+  ;; = expm1(a)*cos(b) + cosm1(b) + j*exp(a)*sin(b)
+  (let [a (.-re z)
+        b (.-im z)]
+    (->Complex (+ (* (Math/expm1 a) (Math/cos b)) (cos-1 b))
+               (* (Math/exp a) (Math/sin b)))))
 
-;;       // 0 / Infinity = 0
-;;       if (this['isZero']() || z['isInfinite']()) {
-;;         return Complex['ZERO'];
-;;       }
-
-;;       a = this['re'];
-;;       b = this['im'];
-
-;;       var c = z['re'];
-;;       var d = z['im'];
-;;       var t, x;
-
-;;       if (0 === d) {
-;;         // Divisor is real
-;;         return new Complex(a / c, b / c);
-;;       }
-
-;;       if (Math.abs(c) < Math.abs(d)) {
-
-;;         x = c / d;
-;;         t = c * x + d;
-
-;;         return new Complex(
-;;           (a * x + b) / t,
-;;           (b * x - a) / t);
-
-;;       } else {
-
-;;         x = d / c;
-;;         t = d * x + c;
-
-;;         return new Complex(
-;;           (a + b * x) / t,
-;;           (b - a * x) / t);
-;;       }
-;;     },
-
-(defn pow [l r])
-;;     /**
-;;      * Calculate the power of two complex numbers
-;;      *
-;;      * @returns {Complex}
-;;      */
-;;     'pow': function(a, b) {
-
-;;       var z = new Complex(a, b);
-
-;;       a = this['re'];
-;;       b = this['im'];
-
-;;       if (z['isZero']()) {
-;;         return Complex['ONE'];
-;;       }
-
-;;       // If the exponent is real
-;;       if (z['im'] === 0) {
-
-;;         if (b === 0 && a > 0) {
-
-;;           return new Complex(Math.pow(a, z['re']), 0);
-
-;;         } else if (a === 0) { // If base is fully imaginary
-
-;;           switch ((z['re'] % 4 + 4) % 4) {
-;;             case 0:
-;;               return new Complex(Math.pow(b, z['re']), 0);
-;;             case 1:
-;;               return new Complex(0, Math.pow(b, z['re']));
-;;             case 2:
-;;               return new Complex(-Math.pow(b, z['re']), 0);
-;;             case 3:
-;;               return new Complex(0, -Math.pow(b, z['re']));
-;;           }
-;;         }
-;;       }
-
-;;       /* I couldn't find a good formula, so here is a derivation and optimization
-;;        *
-;;        * z_1^z_2 = (a + bi)^(c + di)
-;;        *         = exp((c + di) * log(a + bi)
-;;        *         = pow(a^2 + b^2, (c + di) / 2) * exp(i(c + di)atan2(b, a))
-;;        * =>...
-;;        * Re = (pow(a^2 + b^2, c / 2) * exp(-d * atan2(b, a))) * cos(d * log(a^2 + b^2) / 2 + c * atan2(b, a))
-;;        * Im = (pow(a^2 + b^2, c / 2) * exp(-d * atan2(b, a))) * sin(d * log(a^2 + b^2) / 2 + c * atan2(b, a))
-;;        *
-;;        * =>...
-;;        * Re = exp(c * log(sqrt(a^2 + b^2)) - d * atan2(b, a)) * cos(d * log(sqrt(a^2 + b^2)) + c * atan2(b, a))
-;;        * Im = exp(c * log(sqrt(a^2 + b^2)) - d * atan2(b, a)) * sin(d * log(sqrt(a^2 + b^2)) + c * atan2(b, a))
-;;        *
-;;        * =>
-;;        * Re = exp(c * logsq2 - d * arg(z_1)) * cos(d * logsq2 + c * arg(z_1))
-;;        * Im = exp(c * logsq2 - d * arg(z_1)) * sin(d * logsq2 + c * arg(z_1))
-;;        *
-;;        */
-
-;;       if (a === 0 && b === 0 && z['re'] > 0 && z['im'] >= 0) {
-;;         return Complex['ZERO'];
-;;       }
-
-;;       var arg = Math.atan2(b, a);
-;;       var loh = logHypot(a, b);
-
-;;       a = Math.exp(z['re'] * loh - z['im'] * arg);
-;;       b = z['im'] * loh + z['re'] * arg;
-;;       return new Complex(
-;;         a * Math.cos(b),
-;;         a * Math.sin(b));
-;;     },
-
-(defn sqrt [z])
-;;     /**
-;;      * Calculate the complex square root
-;;      *
-;;      * @returns {Complex}
-;;      */
-;;     'sqrt': function() {
-
-;;       var a = this['re'];
-;;       var b = this['im'];
-;;       var r = this['abs']();
-
-;;       var re, im;
-
-;;       if (a >= 0) {
-
-;;         if (b === 0) {
-;;           return new Complex(Math.sqrt(a), 0);
-;;         }
-
-;;         re = 0.5 * Math.sqrt(2.0 * (r + a));
-;;       } else {
-;;         re = Math.abs(b) / Math.sqrt(2 * (r - a));
-;;       }
-
-;;       if (a <= 0) {
-;;         im = 0.5 * Math.sqrt(2.0 * (r - a));
-;;       } else {
-;;         im = Math.abs(b) / Math.sqrt(2 * (r + a));
-;;       }
-
-;;       return new Complex(re, b < 0 ? -im : im);
-;;     },
-
-(defn exp [z])
-;;     /**
-;;      * Calculate the complex exponent
-;;      *
-;;      * @returns {Complex}
-;;      */
-;;     'exp': function() {
-
-;;       var tmp = Math.exp(this['re']);
-
-;;       if (this['im'] === 0) {
-;;         //return new Complex(tmp, 0);
-;;       }
-;;       return new Complex(
-;;         tmp * Math.cos(this['im']),
-;;         tmp * Math.sin(this['im']));
-;;     },
-
-(defn exp-1 [z])
-;;     /**
-;;      * Calculate the complex exponent and subtracts one.
-;;      *
-;;      * This may be more accurate than `Complex(x).exp().sub(1)` if
-;;      * `x` is small.
-;;      *
-;;      * @returns {Complex}
-;;      */
-;;     'expm1': function() {
-
-;;       /**
-;;        * exp(a + i*b) - 1
-;;        = exp(a) * (cos(b) + j*sin(b)) - 1
-;;        = expm1(a)*cos(b) + cosm1(b) + j*exp(a)*sin(b)
-;;        */
-
-;;       var a = this['re'];
-;;       var b = this['im'];
-
-;;       return new Complex(
-;;         Math.expm1(a) * Math.cos(b) + cosm1(b),
-;;         Math.exp(a) * Math.sin(b));
-;;     },
-
-(defn log [z])
-;;     /**
-;;      * Calculate the natural log
-;;      *
-;;      * @returns {Complex}
-;;      */
-;;     'log': function() {
-
-;;       var a = this['re'];
-;;       var b = this['im'];
-
-;;       if (b === 0 && a > 0) {
-;;         //return new Complex(Math.log(a), 0);
-;;       }
-
-;;       return new Complex(
-;;         logHypot(a, b),
-;;         Math.atan2(b, a));
-;;     },
+(defn log
+  "Calculate the natural log"
+  [^Complex z]
+  (let [a (.-re z)
+        b (.-im z)]
+   (->Complex (log-hypot z) (Math/atan2 b a))))
 
 (defn arg
   "Calculate the angle of the complex number"
   [^Complex z]
-  (Math/atan2(.-im z) (.-re z)))
+  (Math/atan2 (.-im z) (.-re z)))
 
-(defn sin [z])
-;;     /**
-;;      * Calculate the sine of the complex number
-;;      *
-;;      * @returns {Complex}
-;;      */
-;;     'sin': function() {
+(defn sin
+  [^Complex z]
+  ;; sin(z) = ( e^iz - e^-iz ) / 2i
+  ;;        = sin(a)cosh(b) + i cos(a)sinh(b)
+  (let [a (.-re z)
+        b (.-im z)]
+    (->Complex (* (Math/sin a) (Math/cosh b))
+               (* (Math/cos a) (Math/sinh b)))))
 
-;;       // sin(z) = ( e^iz - e^-iz ) / 2i
-;;       //        = sin(a)cosh(b) + i cos(a)sinh(b)
+(defn cos
+  [^Complex z]
+  ;; cos(z) = ( e^iz + e^-iz ) / 2
+  ;;        = cos(a)cosh(b) - i sin(a)sinh(b)
+  (let [a (.-re z)
+        b (.-im z)]
+    (->Complex (* (Math/cos a) (Math/cosh b))
+               (* -1 (Math/sin a) (Math/sinh b)))))
 
-;;       var a = this['re'];
-;;       var b = this['im'];
+(defn tan
+  [^Complex z]
+  ;; tan(z) = sin(z) / cos(z)
+  ;;        = ( e^iz - e^-iz ) / ( i( e^iz + e^-iz ) )
+  ;;        = ( e^2iz - 1 ) / i( e^2iz + 1 )
+  ;;        = ( sin(2a) + i sinh(2b) ) / ( cos(2a) + cosh(2b) )
+  (let [a (g/* 2 (.-re z))
+        b (g/* 2 (.-im z))
+        d (g/+ (g/cos a) (g/cosh b))]
+    (->Complex (g// (g/sin a) d)
+               (g// (g/sinh b) d))))
 
-;;       return new Complex(
-;;         Math.sin(a) * cosh(b),
-;;         Math.cos(a) * sinh(b));
-;;     },
+(defn cot
+  [^Complex z]
+  ;; cot(c) = i(e^(ci) + e^(-ci)) / (e^(ci) - e^(-ci))
+  (let [a (g/* 2 (.-re z))
+        b (g/* 2 (.-im z))
+        d (g/- (g/cos a) (g/cosh b))]
+    (->Complex (g// (g/negate (g/sin a)) d)
+               (g// (g/sinh b) d))))
 
-(defn cos [z])
-;;     /**
-;;      * Calculate the cosine
-;;      *
-;;      * @returns {Complex}
-;;      */
-;;     'cos': function() {
+(defn sec
+  [^Complex z]
+  (let [a (.-re z)
+        b (.-im z)
+        d (* 0.5 (+ (Math/cosh (* 2 b)) (Math/cos (* 2 a))))]
+    ;; sec(c) = 2 / (e^(ci) + e^(-ci))
+    (->Complex (/ (* (Math/cos a) (Math/cosh b)) d)
+               (/ (* (Math/sin a) (Math/sinh b)) d))))
 
-;;       // cos(z) = ( e^iz + e^-iz ) / 2
-;;       //        = cos(a)cosh(b) - i sin(a)sinh(b)
+(defn csc
+  [^Complex z]
+  ;; csc(c) = 2i / (e^(ci) - e^(-ci))
+  (let [a (.-re z)
+        b (.-im z)
+        d (* 0.5 (- (Math/cosh (* 2 b)) (Math/cos (* 2 a))))]
+    (->Complex (/ (* (Math/sin a) (Math/cosh b)) d)
+               (/ (* -1 (Math/cos a) (Math/sinh b)) d))))
 
-;;       var a = this['re'];
-;;       var b = this['im'];
+(defn asin
+  "Calculate the complex arc sine"
+  [^Complex z]
+  (let [a (.-re z)
+        b (.-im z)
+        t1 (sqrt (->Complex (- (* b b) (* a a) -1)
+                            (* -2 a b)))
+        t2 (log (->Complex (- (.-re t1) b)
+                           (+ (.-im t1) a)))]
+    (->Complex (.-im t2) (- (.-re t2)))))
 
-;;       return new Complex(
-;;         Math.cos(a) * cosh(b),
-;;         -Math.sin(a) * sinh(b));
-;;     },
+(defn acos
+  "Calculate the complex arc cosine"
+  [^Complex z]
+  ;; acos(c) = i * log(c - i * sqrt(1 - c^2))
+  (let [a (.-re z)
+        b (.-im z)
+        t1 (sqrt (->Complex (- (* b b) (* a a) -1)
+                            (* -2 a b)))
+        t2 (log (->Complex (- (.-re t1) b)
+                           (+ (.-im t1) a)))]
+    (->Complex (- (/ Math/PI 2) (.-im t2))
+               (.-re t2))))
 
-(defn tan [z])
-;;     /**
-;;      * Calculate the tangent
-;;      *
-;;      * @returns {Complex}
-;;      */
-;;     'tan': function() {
+(defn atan
+  "Calculate the complex arctangent"
+  [^Complex z]
+  ;; atan(c) = i / 2 log((i + x) / (i - x))
+  (let [a (.-re z)
+        b (.-im z)]
+    (cond (and (g/zero? a) (g/one? b))
+          (->Complex 0 ##Inf)
 
-;;       // tan(z) = sin(z) / cos(z)
-;;       //        = ( e^iz - e^-iz ) / ( i( e^iz + e^-iz ) )
-;;       //        = ( e^2iz - 1 ) / i( e^2iz + 1 )
-;;       //        = ( sin(2a) + i sinh(2b) ) / ( cos(2a) + cosh(2b) )
+          (and (g/zero? a) (g/one? (g/negate b)))
+          (->Complex 0 ##-Inf)
 
-;;       var a = 2 * this['re'];
-;;       var b = 2 * this['im'];
-;;       var d = Math.cos(a) + cosh(b);
-
-;;       return new Complex(
-;;         Math.sin(a) / d,
-;;         sinh(b) / d);
-;;     },
-
-(defn cot [z])
-;;     /**
-;;      * Calculate the cotangent
-;;      *
-;;      * @returns {Complex}
-;;      */
-;;     'cot': function() {
-
-;;       // cot(c) = i(e^(ci) + e^(-ci)) / (e^(ci) - e^(-ci))
-
-;;       var a = 2 * this['re'];
-;;       var b = 2 * this['im'];
-;;       var d = Math.cos(a) - cosh(b);
-
-;;       return new Complex(
-;;         -Math.sin(a) / d,
-;;         sinh(b) / d);
-;;     },
-
-(defn sec [z])
-;;     /**
-;;      * Calculate the secant
-;;      *
-;;      * @returns {Complex}
-;;      */
-;;     'sec': function() {
-
-;;       // sec(c) = 2 / (e^(ci) + e^(-ci))
-
-;;       var a = this['re'];
-;;       var b = this['im'];
-;;       var d = 0.5 * cosh(2 * b) + 0.5 * Math.cos(2 * a);
-
-;;       return new Complex(
-;;         Math.cos(a) * cosh(b) / d,
-;;         Math.sin(a) * sinh(b) / d);
-;;     },
-
-(defn csc [z])
-;;     /**
-;;      * Calculate the cosecans
-;;      *
-;;      * @returns {Complex}
-;;      */
-;;     'csc': function() {
-
-;;       // csc(c) = 2i / (e^(ci) - e^(-ci))
-
-;;       var a = this['re'];
-;;       var b = this['im'];
-;;       var d = 0.5 * cosh(2 * b) - 0.5 * Math.cos(2 * a);
-
-;;       return new Complex(
-;;         Math.sin(a) * cosh(b) / d,
-;;         -Math.cos(a) * sinh(b) / d);
-;;     },
-
-(defn asin [z])
-;;     /**
-;;      * Calculate the complex arcus sinus
-;;      *
-;;      * @returns {Complex}
-;;      */
-;;     'asin': function() {
-
-;;       // asin(c) = -i * log(ci + sqrt(1 - c^2))
-
-;;       var a = this['re'];
-;;       var b = this['im'];
-
-;;       var t1 = new Complex(
-;;         b * b - a * a + 1,
-;;         -2 * a * b)['sqrt']();
-
-;;       var t2 = new Complex(
-;;         t1['re'] - b,
-;;         t1['im'] + a)['log']();
-
-;;       return new Complex(t2['im'], -t2['re']);
-;;     },
-
-(defn acos [z])
-;;     /**
-;;      * Calculate the complex arcus cosinus
-;;      *
-;;      * @returns {Complex}
-;;      */
-;;     'acos': function() {
-
-;;       // acos(c) = i * log(c - i * sqrt(1 - c^2))
-
-;;       var a = this['re'];
-;;       var b = this['im'];
-
-;;       var t1 = new Complex(
-;;         b * b - a * a + 1,
-;;         -2 * a * b)['sqrt']();
-
-;;       var t2 = new Complex(
-;;         t1['re'] - b,
-;;         t1['im'] + a)['log']();
-
-;;       return new Complex(Math.PI / 2 - t2['im'], t2['re']);
-;;     },
-
-(defn atan [z])
-;;     /**
-;;      * Calculate the complex arcus tangent
-;;      *
-;;      * @returns {Complex}
-;;      */
-;;     'atan': function() {
-
-;;       // atan(c) = i / 2 log((i + x) / (i - x))
-
-;;       var a = this['re'];
-;;       var b = this['im'];
-
-;;       if (a === 0) {
-
-;;         if (b === 1) {
-;;           return new Complex(0, Infinity);
-;;         }
-
-;;         if (b === -1) {
-;;           return new Complex(0, -Infinity);
-;;         }
-;;       }
-
-;;       var d = a * a + (1.0 - b) * (1.0 - b);
-
-;;       var t1 = new Complex(
-;;         (1 - b * b - a * a) / d,
-;;         -2 * a / d).log();
-
-;;       return new Complex(-0.5 * t1['im'], 0.5 * t1['re']);
-;;     },
+          :else
+          (let [d (g/+ (g/* a a)
+                       (g/square (g/- 1 b)))
+                t1 (log (->Complex (g// (g/- 1 (g/square b) (g/square a)) d)
+                                   (g// (g/* -2 a) d)))]
+            (->Complex (g// (.-im t1) -2)
+                       (g// (.-re t1) 2))))))
 
 (defn acot [z])
 ;;     /**
@@ -928,117 +571,63 @@
 ;;           (b !== 0) ? -b / 0 : 0).asin();
 ;;     },
 
-(defn sinh [z])
-;;     /**
-;;      * Calculate the complex sinh
-;;      *
-;;      * @returns {Complex}
-;;      */
-;;     'sinh': function() {
+(defn sinh
+  "Calculate the complex hyperbolic sine"
+  [^Complex z]
+  (let [a (.-re z)
+        b (.-im z)]
+    (->Complex (g/* (g/sinh a) (g/cos b))
+               (g/* (g/cosh a) (g/sin b)))))
 
-;;       // sinh(c) = (e^c - e^-c) / 2
+(defn cosh
+  "Calculate the complex hyperbolic cosine"
+  [^Complex z]
+  (let [a (.-re z)
+        b (.-im z)]
+    (->Complex (g/* (g/cosh a) (g/cos b))
+               (g/* (g/sinh a) (g/sin b)))))
 
-;;       var a = this['re'];
-;;       var b = this['im'];
+(defn tanh
+  "Caclulate the complex hyperbolic tangent"
+  [^Complex z]
+  (let [a (g/* 2 (.-re z))
+        b (g/* 2 (.-im z))
+        d (g/+ (g/cosh a) (g/cos b))]
+    (->Complex (g// (g/sinh a) d)
+               (g// (g/sin b) d))))
 
-;;       return new Complex(
-;;         sinh(a) * Math.cos(b),
-;;         cosh(a) * Math.sin(b));
-;;     },
+(defn coth
+  "Calculate the complex hyperbolic cotangent"
+  [^Complex z]
+  ;; coth(c) = (e^c + e^-c) / (e^c - e^-c)
+  (let [a (g/* 2 (.-re z))
+        b (g/* 2 (.-im z))
+        d (g/- (g/cosh a) (g/cos b))]
+    (->Complex (g// (g/sinh a) d)
+               (g// (g/negate (g/sin b)) d))))
 
-(defn cosh [z])
-;;     /**
-;;      * Calculate the complex cosh
-;;      *
-;;      * @returns {Complex}
-;;      */
-;;     'cosh': function() {
 
-;;       // cosh(c) = (e^c + e^-c) / 2
+(defn csch
+  "Compute the complex hyperbolic cosecant."
+  [^Complex z]
+  ;; csch(c) = 2 / (e^c - e^-c)
+  (let [a (.-re z)
+        b (.-im z)
+        d (g/- (g/cos (g/* 2 b)) (g/cosh (g/* 2 a)))]
+    (->Complex (g// (g/* -2 (g/sinh a) (g/cos b)) d)
+               (g// (g/* 2 (g/cosh a) (g/sin b)) d))))
 
-;;       var a = this['re'];
-;;       var b = this['im'];
 
-;;       return new Complex(
-;;         cosh(a) * Math.cos(b),
-;;         sinh(a) * Math.sin(b));
-;;     },
 
-(defn tanh [z])
-;;     /**
-;;      * Calculate the complex tanh
-;;      *
-;;      * @returns {Complex}
-;;      */
-;;     'tanh': function() {
-
-;;       // tanh(c) = (e^c - e^-c) / (e^c + e^-c)
-
-;;       var a = 2 * this['re'];
-;;       var b = 2 * this['im'];
-;;       var d = cosh(a) + Math.cos(b);
-
-;;       return new Complex(
-;;         sinh(a) / d,
-;;         Math.sin(b) / d);
-;;     },
-
-(defn coth [z])
-;;     /**
-;;      * Calculate the complex coth
-;;      *
-;;      * @returns {Complex}
-;;      */
-;;     'coth': function() {
-
-;;       // coth(c) = (e^c + e^-c) / (e^c - e^-c)
-
-;;       var a = 2 * this['re'];
-;;       var b = 2 * this['im'];
-;;       var d = cosh(a) - Math.cos(b);
-
-;;       return new Complex(
-;;         sinh(a) / d,
-;;         -Math.sin(b) / d);
-;;     },
-
-(defn csch [z])
-;;     /**
-;;      * Calculate the complex coth
-;;      *
-;;      * @returns {Complex}
-;;      */
-;;     'csch': function() {
-
-;;       // csch(c) = 2 / (e^c - e^-c)
-
-;;       var a = this['re'];
-;;       var b = this['im'];
-;;       var d = Math.cos(2 * b) - cosh(2 * a);
-
-;;       return new Complex(
-;;         -2 * sinh(a) * Math.cos(b) / d,
-;;         2 * cosh(a) * Math.sin(b) / d);
-;;     },
-
-(defn sech [z])
-;;     /**
-;;      * Calculate the complex sech
-;;      *
-;;      * @returns {Complex}
-;;      */
-;;     'sech': function() {
-
-;;       // sech(c) = 2 / (e^c + e^-c)
-
-;;       var a = this['re'];
-;;       var b = this['im'];
-;;       var d = Math.cos(2 * b) + cosh(2 * a);
-
-;;       return new Complex(
-;;         2 * cosh(a) * Math.cos(b) / d,
-;;         -2 * sinh(a) * Math.sin(b) / d);
-;;     },
+(defn sech
+  "Calculate the complex hyperbolic secant."
+  [^Complex z]
+  ;; sech(c) = 2 / (e^c + e^-c)
+  (let [a (.-re z)
+        b (.-im z)
+        d (g/+ (g/cos (g/* 2 b)) (g/cosh (g/* 2 a)))]
+    (->Complex (g// (g/* 2 (g/cosh a) (g/cos b)) d)
+               (g// (g/* -2 (g/sinh a) (g/sin b)) d))))
 
 (defn asinh [z])
 ;;     /**
@@ -1064,15 +653,24 @@
 ;;       return res;
 ;;     },
 
-(defn acosh [z])
+(defn acosh
+  "Compute the complex arc hyperbolic cosine"
+  [^Complex z]
+  ;; acosh(c) = log(c + sqrt(c^2 - 1))
+  (let [a (acos z)
+        ra (.-re a)
+        ia (.-im a)]
+    (if (< ia 0)
+      (->Complex (- ia) ra)
+      (->Complex ia (- ra)))))
+
 ;;     /**
-;;      * Calculate the complex acosh
+;;      * Calculate the complex an
 ;;      *
 ;;      * @returns {Complex}
 ;;      */
 ;;     'acosh': function() {
 
-;;       // acosh(c) = log(c + sqrt(c^2 - 1))
 
 ;;       var res = this['acos']();
 ;;       if (res['im'] <= 0) {
@@ -1207,49 +805,35 @@
 ;;           (b !== 0) ? -b / 0 : 0).acosh();
 ;;     },
 
-(defn inverse [z])
-;;     /**
-;;      * Calculate the complex inverse 1/z
-;;      *
-;;      * @returns {Complex}
-;;      */
-;;     'inverse': function() {
-
-;;       // 1 / 0 = Infinity and 1 / Infinity = 0
-;;       if (this['isZero']()) {
-;;         return Complex['INFINITY'];
-;;       }
-
-;;       if (this['isInfinite']()) {
-;;         return Complex['ZERO'];
-;;       }
-
-;;       var a = this['re'];
-;;       var b = this['im'];
-
-;;       var d = a * a + b * b;
-
-;;       return new Complex(a / d, -b / d);
-;;     },
+(defn inverse
+  "Calculate the complex inverse 1/z"
+  [z]
+  (cond (zero? z) INFINITY
+        (infinite? z) ZERO
+        :else (let [a (.-re z)
+                    b (.-im z)
+                    d (g/+ (g/* a a) (g/* b b))]
+                (->Complex (g// a d)
+                           (g// (g/negate b) d)))))
 
 (defn conjugate
   "Returns the complex conjugate"
   [^Complex z]
-  (build (.-re z)
-         (- (.-im z))))
+  (->Complex (.-re z)
+             (g/negate (.-im z))))
 
 (defn neg
   "Gets the negated complex number"
   [^Complex z]
-  (build (- (.-re z))
-         (- (.-im z))))
+  (->Complex (g/negate (.-re z))
+             (g/negate (.-im z))))
 
 (defn ceil
   "Ceils the actual complex number"
   ([z] (ceil z 0))
   ([z places]
    (let [places (Math/pow 10 places)]
-     (build
+     (->Complex
       (-> (.-re z) (* places) (Math/ceil) (/ places))
       (-> (.-im z) (* places) (Math/ceil) (/ places))))))
 
@@ -1258,7 +842,7 @@
   ([z] (floor z 0))
   ([z places]
    (let [places (Math/pow 10 places)]
-     (build
+     (->Complex
       (-> (.-re z) (* places) (Math/floor) (/ places))
       (-> (.-im z) (* places) (Math/floor) (/ places))))))
 
@@ -1267,134 +851,13 @@
   ([z] (round z 0))
   ([z places]
    (let [places (Math/pow 10 places)]
-     (build
+     (->Complex
       (-> (.-re z) (* places) (Math/round) (/ places))
       (-> (.-im z) (* places) (Math/round) (/ places))))))
 
-(defn equals [z])
-;;     /**
-;;      * Compares two complex numbers
-;;      *
-;;      * **Note:** new Complex(Infinity).equals(Infinity) === false
-;;      *
-;;      * @returns {boolean}
-;;      */
-;;     'equals': function(a, b) {
+(comment
+  (require 'emmy.complex)
+  (read-string {:readers {'emmy/complex emmy.complex/complex}} "#emmy/complex [-1 -1]")
 
-;;       var z = new Complex(a, b);
-
-;;       return Math.abs(z['re'] - this['re']) <= Complex['EPSILON'] &&
-;;         Math.abs(z['im'] - this['im']) <= Complex['EPSILON'];
-;;     },
-
-(defn to-string [z])
-;;     /**
-;;      * Gets a string of the actual complex number
-;;      *
-;;      * @returns {string}
-;;      */
-;;     'toString': function() {
-
-;;       var a = this['re'];
-;;       var b = this['im'];
-;;       var ret = "";
-
-;;       if (this['isNaN']()) {
-;;         return 'NaN';
-;;       }
-
-;;       if (this['isInfinite']()) {
-;;         return 'Infinity';
-;;       }
-
-;;       if (Math.abs(a) < Complex['EPSILON']) {
-;;         a = 0;
-;;       }
-
-;;       if (Math.abs(b) < Complex['EPSILON']) {
-;;         b = 0;
-;;       }
-
-;;       // If is real number
-;;       if (b === 0) {
-;;         return ret + a;
-;;       }
-
-;;       if (a !== 0) {
-;;         ret += a;
-;;         ret += " ";
-;;         if (b < 0) {
-;;           b = -b;
-;;           ret += "-";
-;;         } else {
-;;           ret += "+";
-;;         }
-;;         ret += " ";
-;;       } else if (b < 0) {
-;;         b = -b;
-;;         ret += "-";
-;;       }
-
-;;       if (1 !== b) { // b is the absolute imaginary part
-;;         ret += b;
-;;       }
-;;       return ret + "i";
-;;     },
-
-(defn to-vector
-  "Returns the actual number as a vector"
-  [^Complex z]
-  [(.-re z) (.-im z)])
-
-(defn value-of [z])
-;;     /**
-;;      * Returns the actual real value of the current object
-;;      *
-;;      * @returns {number|null}
-;;      */
-;;     'valueOf': function() {
-
-;;       if (this['im'] === 0) {
-;;         return this['re'];
-;;       }
-;;       return null;
-;;     },
-
-(defn is-nan [z])
-;;     /**
-;;      * Determines whether a complex number is not on the Riemann sphere.
-;;      *
-;;      * @returns {boolean}
-;;      */
-;;     'isNaN': function() {
-;;       return isNaN(this['re']) || isNaN(this['im']);
-;;     },
-
-(defn is-zero [z])
-;;     /**
-;;      * Determines whether or not a complex number is at the zero pole of the
-;;      * Riemann sphere.
-;;      *
-;;      * @returns {boolean}
-;;      */
-;;     'isZero': function() {
-;;       return this['im'] === 0 && this['re'] === 0;
-;;     },
-
-(defn is-finite [z])
-;;     /**
-;;      * Determines whether a complex number is not at the infinity pole of the
-;;      * Riemann sphere.
-;;      *
-;;      * @returns {boolean}
-;;      */
-;;     'isFinite': function() {
-;;       return isFinite(this['re']) && isFinite(this['im']);
-;;     },
-
-(defn is-infinite
-  "Determines whether or not a complex number is at the infinity pole of the Riemann sphere."
-  [z]
-  (not
-   (or (is-nan z)
-       (is-finite z))))
+  (g/conjugate (emmy.complex/complex [-1 -1]))
+  )

--- a/src/emmy/complex/impl.cljc
+++ b/src/emmy/complex/impl.cljc
@@ -1,0 +1,1400 @@
+;; /**
+;;  * @license Complex.js v2.1.1 12/05/2020
+;;  *
+;;  * Copyright (c) 2020, Robert Eisele (robert@xarg.org)
+;;  * Dual licensed under the MIT or GPL Version 2 licenses.
+;;  **/
+
+(ns emmy.complex.impl
+  (:refer-clojure :exclude [abs]))
+
+(deftype Complex [re im])
+
+(def ZERO (Complex. 0 0))
+(def ONE (Complex. 1 0))
+(def I (Complex. 0 1))
+(def PI (Complex. Math/PI 0))
+(def E (Complex. Math/E 0))
+(def INFINITY (Complex. ##Inf ##Inf))
+
+(def NAN
+  #?(:cljs (Complex. js/NaN js/NaN)
+     :clj  (Complex. Double/NaN Double/NaN)))
+
+(def EPSILON 1e-15)
+
+;; /**
+;;  *
+;;  * This class allows the manipulation of complex numbers.
+;;  * You can pass a complex number in different formats. Either as object, double, string or two integer parameters.
+;;  *
+;;  * Object form
+;;  * { re: <real>, im: <imaginary> }
+;;  * { arg: <angle>, abs: <radius> }
+;;  * { phi: <angle>, r: <radius> }
+;;  *
+;;  * Array / Vector form
+;;  * [ real, imaginary ]
+;;  *
+;;  * Double form
+;;  * 99.3 - Single double value
+;;  *
+;;  * String form
+;;  * '23.1337' - Simple real number
+;;  * '15+3i' - a simple complex number
+;;  * '3-i' - a simple complex number
+;;  *
+;;  * Example:
+;;  *
+;;  * var c = new Complex('99.3+8i');
+;;  * c.mul({r: 3, i: 9}).div(4.9).sub(3, 2);
+;;  *
+;;  */
+
+(defn cos-1 [x])
+;;   /**
+;;    * Calculates cos(x) - 1 using Taylor series if x is small (-¼π ≤ x ≤ ¼π).
+;;    *
+;;    * @param {number} x
+;;    * @returns {number} cos(x) - 1
+;;    */
+;;   var cosm1 = function(x) {
+
+;;     var b = Math.PI / 4;
+;;     if (-b > x || x > b) {
+;;       return Math.cos(x) - 1.0;
+;;     }
+
+;;     /* Calculate horner form of polynomial of taylor series in Q
+;;     var fac = 1, alt = 1, pol = {};
+;;     for (var i = 0; i <= 16; i++) {
+;;       fac*= i || 1;
+;;       if (i % 2 == 0) {
+;;         pol[i] = new Fraction(1, alt * fac);
+;;         alt = -alt;
+;;       }
+;;     }
+;;     console.log(new Polynomial(pol).toHorner()); // (((((((1/20922789888000x^2-1/87178291200)x^2+1/479001600)x^2-1/3628800)x^2+1/40320)x^2-1/720)x^2+1/24)x^2-1/2)x^2+1
+;;     */
+
+;;     var xx = x * x;
+;;     return xx * (
+;;       xx * (
+;;         xx * (
+;;           xx * (
+;;             xx * (
+;;               xx * (
+;;                 xx * (
+;;                   xx / 20922789888000
+;;                   - 1 / 87178291200)
+;;                 + 1 / 479001600)
+;;               - 1 / 3628800)
+;;             + 1 / 40320)
+;;           - 1 / 720)
+;;         + 1 / 24)
+;;       - 1 / 2);
+;;   };
+
+(defn hypot [x y])
+
+;;   var hypot = function(x, y) {
+
+;;     var a = Math.abs(x);
+;;     var b = Math.abs(y);
+
+;;     if (a < 3000 && b < 3000) {
+;;       return Math.sqrt(a * a + b * b);
+;;     }
+
+;;     if (a < b) {
+;;       a = b;
+;;       b = x / y;
+;;     } else {
+;;       b = y / x;
+;;     }
+;;     return a * Math.sqrt(1 + b * b);
+;;   };
+
+;;   var parser_exit = function() {
+;;     throw SyntaxError('Invalid Param');
+;;   };
+
+(defn log-hypot [x])
+
+;;   /**
+;;    * Calculates log(sqrt(a^2+b^2)) in a way to avoid overflows
+;;    *
+;;    * @param {number} a
+;;    * @param {number} b
+;;    * @returns {number}
+;;    */
+;;   function logHypot(a, b) {
+
+;;     var _a = Math.abs(a);
+;;     var _b = Math.abs(b);
+
+;;     if (a === 0) {
+;;       return Math.log(_b);
+;;     }
+
+;;     if (b === 0) {
+;;       return Math.log(_a);
+;;     }
+
+;;     if (_a < 3000 && _b < 3000) {
+;;       return Math.log(a * a + b * b) * 0.5;
+;;     }
+
+;;     /* I got 4 ideas to compute this property without overflow:
+;;      *
+;;      * Testing 1000000 times with random samples for a,b ∈ [1, 1000000000] against a big decimal library to get an error estimate
+;;      *
+;;      * 1. Only eliminate the square root: (OVERALL ERROR: 3.9122483030951116e-11)
+
+;;      Math.log(a * a + b * b) / 2
+
+;;      *
+;;      *
+;;      * 2. Try to use the non-overflowing pythagoras: (OVERALL ERROR: 8.889760039210159e-10)
+
+;;      var fn = function(a, b) {
+;;      a = Math.abs(a);
+;;      b = Math.abs(b);
+;;      var t = Math.min(a, b);
+;;      a = Math.max(a, b);
+;;      t = t / a;
+
+;;      return Math.log(a) + Math.log(1 + t * t) / 2;
+;;      };
+
+;;      * 3. Abuse the identity cos(atan(y/x) = x / sqrt(x^2+y^2): (OVERALL ERROR: 3.4780178737037204e-10)
+
+;;      Math.log(a / Math.cos(Math.atan2(b, a)))
+
+;;      * 4. Use 3. and apply log rules: (OVERALL ERROR: 1.2014087502620896e-9)
+
+;;      Math.log(a) - Math.log(Math.cos(Math.atan2(b, a)))
+
+;;      */
+
+;;      a = a / 2;
+;;      b = b / 2;
+
+;;     return 0.5 * Math.log(a * a + b * b) + Math.LN2;
+;;   }
+
+(defn parse [a b])
+
+;;   var parse = function(a, b) {
+
+;;     var z = { 're': 0, 'im': 0 };
+
+;;     if (a === undefined || a === null) {
+;;       z['re'] =
+;;       z['im'] = 0;
+;;     } else if (b !== undefined) {
+;;       z['re'] = a;
+;;       z['im'] = b;
+;;     } else
+;;       switch (typeof a) {
+
+;;         case 'object':
+
+;;           if ('im' in a && 're' in a) {
+;;             z['re'] = a['re'];
+;;             z['im'] = a['im'];
+;;           } else if ('abs' in a && 'arg' in a) {
+;;             if (!Number.isFinite(a['abs']) && Number.isFinite(a['arg'])) {
+;;               return Complex['INFINITY'];
+;;             }
+;;             z['re'] = a['abs'] * Math.cos(a['arg']);
+;;             z['im'] = a['abs'] * Math.sin(a['arg']);
+;;           } else if ('r' in a && 'phi' in a) {
+;;             if (!Number.isFinite(a['r']) && Number.isFinite(a['phi'])) {
+;;               return Complex['INFINITY'];
+;;             }
+;;             z['re'] = a['r'] * Math.cos(a['phi']);
+;;             z['im'] = a['r'] * Math.sin(a['phi']);
+;;           } else if (a.length === 2) { // Quick array check
+;;             z['re'] = a[0];
+;;             z['im'] = a[1];
+;;           } else {
+;;             parser_exit();
+;;           }
+;;           break;
+
+;;         case 'string':
+
+;;           z['im'] = /* void */
+;;           z['re'] = 0;
+
+;;           var tokens = a.match(/\d+\.?\d*e[+-]?\d+|\d+\.?\d*|\.\d+|./g);
+;;           var plus = 1;
+;;           var minus = 0;
+
+;;           if (tokens === null) {
+;;             parser_exit();
+;;           }
+
+;;           for (var i = 0; i < tokens.length; i++) {
+
+;;             var c = tokens[i];
+
+;;             if (c === ' ' || c === '\t' || c === '\n') {
+;;               /* void */
+;;             } else if (c === '+') {
+;;               plus++;
+;;             } else if (c === '-') {
+;;               minus++;
+;;             } else if (c === 'i' || c === 'I') {
+
+;;               if (plus + minus === 0) {
+;;                 parser_exit();
+;;               }
+
+;;               if (tokens[i + 1] !== ' ' && !isNaN(tokens[i + 1])) {
+;;                 z['im'] += parseFloat((minus % 2 ? '-' : '') + tokens[i + 1]);
+;;                 i++;
+;;               } else {
+;;                 z['im'] += parseFloat((minus % 2 ? '-' : '') + '1');
+;;               }
+;;               plus = minus = 0;
+
+;;             } else {
+
+;;               if (plus + minus === 0 || isNaN(c)) {
+;;                 parser_exit();
+;;               }
+
+;;               if (tokens[i + 1] === 'i' || tokens[i + 1] === 'I') {
+;;                 z['im'] += parseFloat((minus % 2 ? '-' : '') + c);
+;;                 i++;
+;;               } else {
+;;                 z['re'] += parseFloat((minus % 2 ? '-' : '') + c);
+;;               }
+;;               plus = minus = 0;
+;;             }
+;;           }
+
+;;           // Still something on the stack
+;;           if (plus + minus > 0) {
+;;             parser_exit();
+;;           }
+;;           break;
+
+;;         case 'number':
+;;           z['im'] = 0;
+;;           z['re'] = a;
+;;           break;
+
+;;         default:
+;;           parser_exit();
+;;       }
+
+;;     if (isNaN(z['re']) || isNaN(z['im'])) {
+;;       // If a calculation is NaN, we treat it as NaN and don't throw
+;;       //parser_exit();
+;;     }
+
+;;     return z;
+;;   };
+
+(deftype Complex [re im])
+
+(defn build [a b]
+  (->Complex a b))
+
+;;   /**
+;;    * @constructor
+;;    * @returns {Complex}
+;;    */
+;;   function Complex(a, b) {
+
+;;     if (!(this instanceof Complex)) {
+;;       return new Complex(a, b);
+;;     }
+
+;;     var z = parse(a, b);
+
+;;     this['re'] = z['re'];
+;;     this['im'] = z['im'];
+;;   }
+
+;;   Complex.prototype = {
+
+;;     're': 0,
+;;     'im': 0,
+
+(defn abs
+  "Calculate the magnitude of the complex number"
+  [^Complex z]
+  (hypot (.-re z) (.-im z)))
+
+(defn sign
+  "Calculates the sign of a complex number, which is a normalized complex"
+  [z]
+  (let [abs-z (abs z)]
+    (build
+     (/ (.-re z) abs-z)
+     (/ (.-im z) abs-z))))
+
+(defn add [l r])
+;;     /**
+;;      * Adds two complex numbers
+;;      *
+;;      * @returns {Complex}
+;;      */
+;;     'add': function(a, b) {
+
+;;       var z = new Complex(a, b);
+
+;;       // Infinity + Infinity = NaN
+;;       if (this['isInfinite']() && z['isInfinite']()) {
+;;         return Complex['NAN'];
+;;       }
+
+;;       // Infinity + z = Infinity { where z != Infinity }
+;;       if (this['isInfinite']() || z['isInfinite']()) {
+;;         return Complex['INFINITY'];
+;;       }
+
+;;       return new Complex(
+;;         this['re'] + z['re'],
+;;         this['im'] + z['im']);
+;;     },
+
+(defn sub [l r])
+;;     /**
+;;      * Subtracts two complex numbers
+;;      *
+;;      * @returns {Complex}
+;;      */
+;;     'sub': function(a, b) {
+
+;;       var z = new Complex(a, b);
+
+;;       // Infinity - Infinity = NaN
+;;       if (this['isInfinite']() && z['isInfinite']()) {
+;;         return Complex['NAN'];
+;;       }
+
+;;       // Infinity - z = Infinity { where z != Infinity }
+;;       if (this['isInfinite']() || z['isInfinite']()) {
+;;         return Complex['INFINITY'];
+;;       }
+
+;;       return new Complex(
+;;         this['re'] - z['re'],
+;;         this['im'] - z['im']);
+;;     },
+
+(defn mul [l r])
+;;     /**
+;;      * Multiplies two complex numbers
+;;      *
+;;      * @returns {Complex}
+;;      */
+;;     'mul': function(a, b) {
+
+;;       var z = new Complex(a, b);
+
+;;       // Infinity * 0 = NaN
+;;       if ((this['isInfinite']() && z['isZero']()) || (this['isZero']() && z['isInfinite']())) {
+;;         return Complex['NAN'];
+;;       }
+
+;;       // Infinity * z = Infinity { where z != 0 }
+;;       if (this['isInfinite']() || z['isInfinite']()) {
+;;         return Complex['INFINITY'];
+;;       }
+
+;;       // Short circuit for real values
+;;       if (z['im'] === 0 && this['im'] === 0) {
+;;         return new Complex(this['re'] * z['re'], 0);
+;;       }
+
+;;       return new Complex(
+;;         this['re'] * z['re'] - this['im'] * z['im'],
+;;         this['re'] * z['im'] + this['im'] * z['re']);
+;;     },
+
+(defn div [l r])
+;;     /**
+;;      * Divides two complex numbers
+;;      *
+;;      * @returns {Complex}
+;;      */
+;;     'div': function(a, b) {
+
+;;       var z = new Complex(a, b);
+
+;;       // 0 / 0 = NaN and Infinity / Infinity = NaN
+;;       if ((this['isZero']() && z['isZero']()) || (this['isInfinite']() && z['isInfinite']())) {
+;;         return Complex['NAN'];
+;;       }
+
+;;       // Infinity / 0 = Infinity
+;;       if (this['isInfinite']() || z['isZero']()) {
+;;         return Complex['INFINITY'];
+;;       }
+
+;;       // 0 / Infinity = 0
+;;       if (this['isZero']() || z['isInfinite']()) {
+;;         return Complex['ZERO'];
+;;       }
+
+;;       a = this['re'];
+;;       b = this['im'];
+
+;;       var c = z['re'];
+;;       var d = z['im'];
+;;       var t, x;
+
+;;       if (0 === d) {
+;;         // Divisor is real
+;;         return new Complex(a / c, b / c);
+;;       }
+
+;;       if (Math.abs(c) < Math.abs(d)) {
+
+;;         x = c / d;
+;;         t = c * x + d;
+
+;;         return new Complex(
+;;           (a * x + b) / t,
+;;           (b * x - a) / t);
+
+;;       } else {
+
+;;         x = d / c;
+;;         t = d * x + c;
+
+;;         return new Complex(
+;;           (a + b * x) / t,
+;;           (b - a * x) / t);
+;;       }
+;;     },
+
+(defn pow [l r])
+;;     /**
+;;      * Calculate the power of two complex numbers
+;;      *
+;;      * @returns {Complex}
+;;      */
+;;     'pow': function(a, b) {
+
+;;       var z = new Complex(a, b);
+
+;;       a = this['re'];
+;;       b = this['im'];
+
+;;       if (z['isZero']()) {
+;;         return Complex['ONE'];
+;;       }
+
+;;       // If the exponent is real
+;;       if (z['im'] === 0) {
+
+;;         if (b === 0 && a > 0) {
+
+;;           return new Complex(Math.pow(a, z['re']), 0);
+
+;;         } else if (a === 0) { // If base is fully imaginary
+
+;;           switch ((z['re'] % 4 + 4) % 4) {
+;;             case 0:
+;;               return new Complex(Math.pow(b, z['re']), 0);
+;;             case 1:
+;;               return new Complex(0, Math.pow(b, z['re']));
+;;             case 2:
+;;               return new Complex(-Math.pow(b, z['re']), 0);
+;;             case 3:
+;;               return new Complex(0, -Math.pow(b, z['re']));
+;;           }
+;;         }
+;;       }
+
+;;       /* I couldn't find a good formula, so here is a derivation and optimization
+;;        *
+;;        * z_1^z_2 = (a + bi)^(c + di)
+;;        *         = exp((c + di) * log(a + bi)
+;;        *         = pow(a^2 + b^2, (c + di) / 2) * exp(i(c + di)atan2(b, a))
+;;        * =>...
+;;        * Re = (pow(a^2 + b^2, c / 2) * exp(-d * atan2(b, a))) * cos(d * log(a^2 + b^2) / 2 + c * atan2(b, a))
+;;        * Im = (pow(a^2 + b^2, c / 2) * exp(-d * atan2(b, a))) * sin(d * log(a^2 + b^2) / 2 + c * atan2(b, a))
+;;        *
+;;        * =>...
+;;        * Re = exp(c * log(sqrt(a^2 + b^2)) - d * atan2(b, a)) * cos(d * log(sqrt(a^2 + b^2)) + c * atan2(b, a))
+;;        * Im = exp(c * log(sqrt(a^2 + b^2)) - d * atan2(b, a)) * sin(d * log(sqrt(a^2 + b^2)) + c * atan2(b, a))
+;;        *
+;;        * =>
+;;        * Re = exp(c * logsq2 - d * arg(z_1)) * cos(d * logsq2 + c * arg(z_1))
+;;        * Im = exp(c * logsq2 - d * arg(z_1)) * sin(d * logsq2 + c * arg(z_1))
+;;        *
+;;        */
+
+;;       if (a === 0 && b === 0 && z['re'] > 0 && z['im'] >= 0) {
+;;         return Complex['ZERO'];
+;;       }
+
+;;       var arg = Math.atan2(b, a);
+;;       var loh = logHypot(a, b);
+
+;;       a = Math.exp(z['re'] * loh - z['im'] * arg);
+;;       b = z['im'] * loh + z['re'] * arg;
+;;       return new Complex(
+;;         a * Math.cos(b),
+;;         a * Math.sin(b));
+;;     },
+
+(defn sqrt [z])
+;;     /**
+;;      * Calculate the complex square root
+;;      *
+;;      * @returns {Complex}
+;;      */
+;;     'sqrt': function() {
+
+;;       var a = this['re'];
+;;       var b = this['im'];
+;;       var r = this['abs']();
+
+;;       var re, im;
+
+;;       if (a >= 0) {
+
+;;         if (b === 0) {
+;;           return new Complex(Math.sqrt(a), 0);
+;;         }
+
+;;         re = 0.5 * Math.sqrt(2.0 * (r + a));
+;;       } else {
+;;         re = Math.abs(b) / Math.sqrt(2 * (r - a));
+;;       }
+
+;;       if (a <= 0) {
+;;         im = 0.5 * Math.sqrt(2.0 * (r - a));
+;;       } else {
+;;         im = Math.abs(b) / Math.sqrt(2 * (r + a));
+;;       }
+
+;;       return new Complex(re, b < 0 ? -im : im);
+;;     },
+
+(defn exp [z])
+;;     /**
+;;      * Calculate the complex exponent
+;;      *
+;;      * @returns {Complex}
+;;      */
+;;     'exp': function() {
+
+;;       var tmp = Math.exp(this['re']);
+
+;;       if (this['im'] === 0) {
+;;         //return new Complex(tmp, 0);
+;;       }
+;;       return new Complex(
+;;         tmp * Math.cos(this['im']),
+;;         tmp * Math.sin(this['im']));
+;;     },
+
+(defn exp-1 [z])
+;;     /**
+;;      * Calculate the complex exponent and subtracts one.
+;;      *
+;;      * This may be more accurate than `Complex(x).exp().sub(1)` if
+;;      * `x` is small.
+;;      *
+;;      * @returns {Complex}
+;;      */
+;;     'expm1': function() {
+
+;;       /**
+;;        * exp(a + i*b) - 1
+;;        = exp(a) * (cos(b) + j*sin(b)) - 1
+;;        = expm1(a)*cos(b) + cosm1(b) + j*exp(a)*sin(b)
+;;        */
+
+;;       var a = this['re'];
+;;       var b = this['im'];
+
+;;       return new Complex(
+;;         Math.expm1(a) * Math.cos(b) + cosm1(b),
+;;         Math.exp(a) * Math.sin(b));
+;;     },
+
+(defn log [z])
+;;     /**
+;;      * Calculate the natural log
+;;      *
+;;      * @returns {Complex}
+;;      */
+;;     'log': function() {
+
+;;       var a = this['re'];
+;;       var b = this['im'];
+
+;;       if (b === 0 && a > 0) {
+;;         //return new Complex(Math.log(a), 0);
+;;       }
+
+;;       return new Complex(
+;;         logHypot(a, b),
+;;         Math.atan2(b, a));
+;;     },
+
+(defn arg
+  "Calculate the angle of the complex number"
+  [^Complex z]
+  (Math/atan2(.-im z) (.-re z)))
+
+(defn sin [z])
+;;     /**
+;;      * Calculate the sine of the complex number
+;;      *
+;;      * @returns {Complex}
+;;      */
+;;     'sin': function() {
+
+;;       // sin(z) = ( e^iz - e^-iz ) / 2i
+;;       //        = sin(a)cosh(b) + i cos(a)sinh(b)
+
+;;       var a = this['re'];
+;;       var b = this['im'];
+
+;;       return new Complex(
+;;         Math.sin(a) * cosh(b),
+;;         Math.cos(a) * sinh(b));
+;;     },
+
+(defn cos [z])
+;;     /**
+;;      * Calculate the cosine
+;;      *
+;;      * @returns {Complex}
+;;      */
+;;     'cos': function() {
+
+;;       // cos(z) = ( e^iz + e^-iz ) / 2
+;;       //        = cos(a)cosh(b) - i sin(a)sinh(b)
+
+;;       var a = this['re'];
+;;       var b = this['im'];
+
+;;       return new Complex(
+;;         Math.cos(a) * cosh(b),
+;;         -Math.sin(a) * sinh(b));
+;;     },
+
+(defn tan [z])
+;;     /**
+;;      * Calculate the tangent
+;;      *
+;;      * @returns {Complex}
+;;      */
+;;     'tan': function() {
+
+;;       // tan(z) = sin(z) / cos(z)
+;;       //        = ( e^iz - e^-iz ) / ( i( e^iz + e^-iz ) )
+;;       //        = ( e^2iz - 1 ) / i( e^2iz + 1 )
+;;       //        = ( sin(2a) + i sinh(2b) ) / ( cos(2a) + cosh(2b) )
+
+;;       var a = 2 * this['re'];
+;;       var b = 2 * this['im'];
+;;       var d = Math.cos(a) + cosh(b);
+
+;;       return new Complex(
+;;         Math.sin(a) / d,
+;;         sinh(b) / d);
+;;     },
+
+(defn cot [z])
+;;     /**
+;;      * Calculate the cotangent
+;;      *
+;;      * @returns {Complex}
+;;      */
+;;     'cot': function() {
+
+;;       // cot(c) = i(e^(ci) + e^(-ci)) / (e^(ci) - e^(-ci))
+
+;;       var a = 2 * this['re'];
+;;       var b = 2 * this['im'];
+;;       var d = Math.cos(a) - cosh(b);
+
+;;       return new Complex(
+;;         -Math.sin(a) / d,
+;;         sinh(b) / d);
+;;     },
+
+(defn sec [z])
+;;     /**
+;;      * Calculate the secant
+;;      *
+;;      * @returns {Complex}
+;;      */
+;;     'sec': function() {
+
+;;       // sec(c) = 2 / (e^(ci) + e^(-ci))
+
+;;       var a = this['re'];
+;;       var b = this['im'];
+;;       var d = 0.5 * cosh(2 * b) + 0.5 * Math.cos(2 * a);
+
+;;       return new Complex(
+;;         Math.cos(a) * cosh(b) / d,
+;;         Math.sin(a) * sinh(b) / d);
+;;     },
+
+(defn csc [z])
+;;     /**
+;;      * Calculate the cosecans
+;;      *
+;;      * @returns {Complex}
+;;      */
+;;     'csc': function() {
+
+;;       // csc(c) = 2i / (e^(ci) - e^(-ci))
+
+;;       var a = this['re'];
+;;       var b = this['im'];
+;;       var d = 0.5 * cosh(2 * b) - 0.5 * Math.cos(2 * a);
+
+;;       return new Complex(
+;;         Math.sin(a) * cosh(b) / d,
+;;         -Math.cos(a) * sinh(b) / d);
+;;     },
+
+(defn asin [z])
+;;     /**
+;;      * Calculate the complex arcus sinus
+;;      *
+;;      * @returns {Complex}
+;;      */
+;;     'asin': function() {
+
+;;       // asin(c) = -i * log(ci + sqrt(1 - c^2))
+
+;;       var a = this['re'];
+;;       var b = this['im'];
+
+;;       var t1 = new Complex(
+;;         b * b - a * a + 1,
+;;         -2 * a * b)['sqrt']();
+
+;;       var t2 = new Complex(
+;;         t1['re'] - b,
+;;         t1['im'] + a)['log']();
+
+;;       return new Complex(t2['im'], -t2['re']);
+;;     },
+
+(defn acos [z])
+;;     /**
+;;      * Calculate the complex arcus cosinus
+;;      *
+;;      * @returns {Complex}
+;;      */
+;;     'acos': function() {
+
+;;       // acos(c) = i * log(c - i * sqrt(1 - c^2))
+
+;;       var a = this['re'];
+;;       var b = this['im'];
+
+;;       var t1 = new Complex(
+;;         b * b - a * a + 1,
+;;         -2 * a * b)['sqrt']();
+
+;;       var t2 = new Complex(
+;;         t1['re'] - b,
+;;         t1['im'] + a)['log']();
+
+;;       return new Complex(Math.PI / 2 - t2['im'], t2['re']);
+;;     },
+
+(defn atan [z])
+;;     /**
+;;      * Calculate the complex arcus tangent
+;;      *
+;;      * @returns {Complex}
+;;      */
+;;     'atan': function() {
+
+;;       // atan(c) = i / 2 log((i + x) / (i - x))
+
+;;       var a = this['re'];
+;;       var b = this['im'];
+
+;;       if (a === 0) {
+
+;;         if (b === 1) {
+;;           return new Complex(0, Infinity);
+;;         }
+
+;;         if (b === -1) {
+;;           return new Complex(0, -Infinity);
+;;         }
+;;       }
+
+;;       var d = a * a + (1.0 - b) * (1.0 - b);
+
+;;       var t1 = new Complex(
+;;         (1 - b * b - a * a) / d,
+;;         -2 * a / d).log();
+
+;;       return new Complex(-0.5 * t1['im'], 0.5 * t1['re']);
+;;     },
+
+(defn acot [z])
+;;     /**
+;;      * Calculate the complex arcus cotangent
+;;      *
+;;      * @returns {Complex}
+;;      */
+;;     'acot': function() {
+
+;;       // acot(c) = i / 2 log((c - i) / (c + i))
+
+;;       var a = this['re'];
+;;       var b = this['im'];
+
+;;       if (b === 0) {
+;;         return new Complex(Math.atan2(1, a), 0);
+;;       }
+
+;;       var d = a * a + b * b;
+;;       return (d !== 0)
+;;         ? new Complex(
+;;           a / d,
+;;           -b / d).atan()
+;;         : new Complex(
+;;           (a !== 0) ? a / 0 : 0,
+;;           (b !== 0) ? -b / 0 : 0).atan();
+;;     },
+
+(defn asec [z])
+;;     /**
+;;      * Calculate the complex arcus secant
+;;      *
+;;      * @returns {Complex}
+;;      */
+;;     'asec': function() {
+
+;;       // asec(c) = -i * log(1 / c + sqrt(1 - i / c^2))
+
+;;       var a = this['re'];
+;;       var b = this['im'];
+
+;;       if (a === 0 && b === 0) {
+;;         return new Complex(0, Infinity);
+;;       }
+
+;;       var d = a * a + b * b;
+;;       return (d !== 0)
+;;         ? new Complex(
+;;           a / d,
+;;           -b / d).acos()
+;;         : new Complex(
+;;           (a !== 0) ? a / 0 : 0,
+;;           (b !== 0) ? -b / 0 : 0).acos();
+;;     },
+
+(defn acsc [z])
+;;     /**
+;;      * Calculate the complex arcus cosecans
+;;      *
+;;      * @returns {Complex}
+;;      */
+;;     'acsc': function() {
+
+;;       // acsc(c) = -i * log(i / c + sqrt(1 - 1 / c^2))
+
+;;       var a = this['re'];
+;;       var b = this['im'];
+
+;;       if (a === 0 && b === 0) {
+;;         return new Complex(Math.PI / 2, Infinity);
+;;       }
+
+;;       var d = a * a + b * b;
+;;       return (d !== 0)
+;;         ? new Complex(
+;;           a / d,
+;;           -b / d).asin()
+;;         : new Complex(
+;;           (a !== 0) ? a / 0 : 0,
+;;           (b !== 0) ? -b / 0 : 0).asin();
+;;     },
+
+(defn sinh [z])
+;;     /**
+;;      * Calculate the complex sinh
+;;      *
+;;      * @returns {Complex}
+;;      */
+;;     'sinh': function() {
+
+;;       // sinh(c) = (e^c - e^-c) / 2
+
+;;       var a = this['re'];
+;;       var b = this['im'];
+
+;;       return new Complex(
+;;         sinh(a) * Math.cos(b),
+;;         cosh(a) * Math.sin(b));
+;;     },
+
+(defn cosh [z])
+;;     /**
+;;      * Calculate the complex cosh
+;;      *
+;;      * @returns {Complex}
+;;      */
+;;     'cosh': function() {
+
+;;       // cosh(c) = (e^c + e^-c) / 2
+
+;;       var a = this['re'];
+;;       var b = this['im'];
+
+;;       return new Complex(
+;;         cosh(a) * Math.cos(b),
+;;         sinh(a) * Math.sin(b));
+;;     },
+
+(defn tanh [z])
+;;     /**
+;;      * Calculate the complex tanh
+;;      *
+;;      * @returns {Complex}
+;;      */
+;;     'tanh': function() {
+
+;;       // tanh(c) = (e^c - e^-c) / (e^c + e^-c)
+
+;;       var a = 2 * this['re'];
+;;       var b = 2 * this['im'];
+;;       var d = cosh(a) + Math.cos(b);
+
+;;       return new Complex(
+;;         sinh(a) / d,
+;;         Math.sin(b) / d);
+;;     },
+
+(defn coth [z])
+;;     /**
+;;      * Calculate the complex coth
+;;      *
+;;      * @returns {Complex}
+;;      */
+;;     'coth': function() {
+
+;;       // coth(c) = (e^c + e^-c) / (e^c - e^-c)
+
+;;       var a = 2 * this['re'];
+;;       var b = 2 * this['im'];
+;;       var d = cosh(a) - Math.cos(b);
+
+;;       return new Complex(
+;;         sinh(a) / d,
+;;         -Math.sin(b) / d);
+;;     },
+
+(defn csch [z])
+;;     /**
+;;      * Calculate the complex coth
+;;      *
+;;      * @returns {Complex}
+;;      */
+;;     'csch': function() {
+
+;;       // csch(c) = 2 / (e^c - e^-c)
+
+;;       var a = this['re'];
+;;       var b = this['im'];
+;;       var d = Math.cos(2 * b) - cosh(2 * a);
+
+;;       return new Complex(
+;;         -2 * sinh(a) * Math.cos(b) / d,
+;;         2 * cosh(a) * Math.sin(b) / d);
+;;     },
+
+(defn sech [z])
+;;     /**
+;;      * Calculate the complex sech
+;;      *
+;;      * @returns {Complex}
+;;      */
+;;     'sech': function() {
+
+;;       // sech(c) = 2 / (e^c + e^-c)
+
+;;       var a = this['re'];
+;;       var b = this['im'];
+;;       var d = Math.cos(2 * b) + cosh(2 * a);
+
+;;       return new Complex(
+;;         2 * cosh(a) * Math.cos(b) / d,
+;;         -2 * sinh(a) * Math.sin(b) / d);
+;;     },
+
+(defn asinh [z])
+;;     /**
+;;      * Calculate the complex asinh
+;;      *
+;;      * @returns {Complex}
+;;      */
+;;     'asinh': function() {
+
+;;       // asinh(c) = log(c + sqrt(c^2 + 1))
+
+;;       var tmp = this['im'];
+;;       this['im'] = -this['re'];
+;;       this['re'] = tmp;
+;;       var res = this['asin']();
+
+;;       this['re'] = -this['im'];
+;;       this['im'] = tmp;
+;;       tmp = res['re'];
+
+;;       res['re'] = -res['im'];
+;;       res['im'] = tmp;
+;;       return res;
+;;     },
+
+(defn acosh [z])
+;;     /**
+;;      * Calculate the complex acosh
+;;      *
+;;      * @returns {Complex}
+;;      */
+;;     'acosh': function() {
+
+;;       // acosh(c) = log(c + sqrt(c^2 - 1))
+
+;;       var res = this['acos']();
+;;       if (res['im'] <= 0) {
+;;         var tmp = res['re'];
+;;         res['re'] = -res['im'];
+;;         res['im'] = tmp;
+;;       } else {
+;;         var tmp = res['im'];
+;;         res['im'] = -res['re'];
+;;         res['re'] = tmp;
+;;       }
+;;       return res;
+;;     },
+
+(defn atanh [z])
+;;     /**
+;;      * Calculate the complex atanh
+;;      *
+;;      * @returns {Complex}
+;;      */
+;;     'atanh': function() {
+
+;;       // atanh(c) = log((1+c) / (1-c)) / 2
+
+;;       var a = this['re'];
+;;       var b = this['im'];
+
+;;       var noIM = a > 1 && b === 0;
+;;       var oneMinus = 1 - a;
+;;       var onePlus = 1 + a;
+;;       var d = oneMinus * oneMinus + b * b;
+
+;;       var x = (d !== 0)
+;;         ? new Complex(
+;;           (onePlus * oneMinus - b * b) / d,
+;;           (b * oneMinus + onePlus * b) / d)
+;;         : new Complex(
+;;           (a !== -1) ? (a / 0) : 0,
+;;           (b !== 0) ? (b / 0) : 0);
+
+;;       var temp = x['re'];
+;;       x['re'] = logHypot(x['re'], x['im']) / 2;
+;;       x['im'] = Math.atan2(x['im'], temp) / 2;
+;;       if (noIM) {
+;;         x['im'] = -x['im'];
+;;       }
+;;       return x;
+;;     },
+
+(defn acoth [z])
+;;     /**
+;;      * Calculate the complex acoth
+;;      *
+;;      * @returns {Complex}
+;;      */
+;;     'acoth': function() {
+
+;;       // acoth(c) = log((c+1) / (c-1)) / 2
+
+;;       var a = this['re'];
+;;       var b = this['im'];
+
+;;       if (a === 0 && b === 0) {
+;;         return new Complex(0, Math.PI / 2);
+;;       }
+
+;;       var d = a * a + b * b;
+;;       return (d !== 0)
+;;         ? new Complex(
+;;           a / d,
+;;           -b / d).atanh()
+;;         : new Complex(
+;;           (a !== 0) ? a / 0 : 0,
+;;           (b !== 0) ? -b / 0 : 0).atanh();
+;;     },
+
+(defn acsch [z])
+;;     /**
+;;      * Calculate the complex acsch
+;;      *
+;;      * @returns {Complex}
+;;      */
+;;     'acsch': function() {
+
+;;       // acsch(c) = log((1+sqrt(1+c^2))/c)
+
+;;       var a = this['re'];
+;;       var b = this['im'];
+
+;;       if (b === 0) {
+
+;;         return new Complex(
+;;           (a !== 0)
+;;             ? Math.log(a + Math.sqrt(a * a + 1))
+;;             : Infinity, 0);
+;;       }
+
+;;       var d = a * a + b * b;
+;;       return (d !== 0)
+;;         ? new Complex(
+;;           a / d,
+;;           -b / d).asinh()
+;;         : new Complex(
+;;           (a !== 0) ? a / 0 : 0,
+;;           (b !== 0) ? -b / 0 : 0).asinh();
+;;     },
+
+(defn asech [z])
+;;     /**
+;;      * Calculate the complex asech
+;;      *
+;;      * @returns {Complex}
+;;      */
+;;     'asech': function() {
+
+;;       // asech(c) = log((1+sqrt(1-c^2))/c)
+
+;;       var a = this['re'];
+;;       var b = this['im'];
+
+;;       if (this['isZero']()) {
+;;         return Complex['INFINITY'];
+;;       }
+
+;;       var d = a * a + b * b;
+;;       return (d !== 0)
+;;         ? new Complex(
+;;           a / d,
+;;           -b / d).acosh()
+;;         : new Complex(
+;;           (a !== 0) ? a / 0 : 0,
+;;           (b !== 0) ? -b / 0 : 0).acosh();
+;;     },
+
+(defn inverse [z])
+;;     /**
+;;      * Calculate the complex inverse 1/z
+;;      *
+;;      * @returns {Complex}
+;;      */
+;;     'inverse': function() {
+
+;;       // 1 / 0 = Infinity and 1 / Infinity = 0
+;;       if (this['isZero']()) {
+;;         return Complex['INFINITY'];
+;;       }
+
+;;       if (this['isInfinite']()) {
+;;         return Complex['ZERO'];
+;;       }
+
+;;       var a = this['re'];
+;;       var b = this['im'];
+
+;;       var d = a * a + b * b;
+
+;;       return new Complex(a / d, -b / d);
+;;     },
+
+(defn conjugate
+  "Returns the complex conjugate"
+  [^Complex z]
+  (build (.-re z)
+         (- (.-im z))))
+
+(defn neg
+  "Gets the negated complex number"
+  [^Complex z]
+  (build (- (.-re z))
+         (- (.-im z))))
+
+(defn ceil
+  "Ceils the actual complex number"
+  ([z] (ceil z 0))
+  ([z places]
+   (let [places (Math/pow 10 places)]
+     (build
+      (-> (.-re z) (* places) (Math/ceil) (/ places))
+      (-> (.-im z) (* places) (Math/ceil) (/ places))))))
+
+(defn floor
+  "Floors the actual complex number"
+  ([z] (floor z 0))
+  ([z places]
+   (let [places (Math/pow 10 places)]
+     (build
+      (-> (.-re z) (* places) (Math/floor) (/ places))
+      (-> (.-im z) (* places) (Math/floor) (/ places))))))
+
+(defn round
+  "Rounds the actual complex number"
+  ([z] (round z 0))
+  ([z places]
+   (let [places (Math/pow 10 places)]
+     (build
+      (-> (.-re z) (* places) (Math/round) (/ places))
+      (-> (.-im z) (* places) (Math/round) (/ places))))))
+
+(defn equals [z])
+;;     /**
+;;      * Compares two complex numbers
+;;      *
+;;      * **Note:** new Complex(Infinity).equals(Infinity) === false
+;;      *
+;;      * @returns {boolean}
+;;      */
+;;     'equals': function(a, b) {
+
+;;       var z = new Complex(a, b);
+
+;;       return Math.abs(z['re'] - this['re']) <= Complex['EPSILON'] &&
+;;         Math.abs(z['im'] - this['im']) <= Complex['EPSILON'];
+;;     },
+
+(defn to-string [z])
+;;     /**
+;;      * Gets a string of the actual complex number
+;;      *
+;;      * @returns {string}
+;;      */
+;;     'toString': function() {
+
+;;       var a = this['re'];
+;;       var b = this['im'];
+;;       var ret = "";
+
+;;       if (this['isNaN']()) {
+;;         return 'NaN';
+;;       }
+
+;;       if (this['isInfinite']()) {
+;;         return 'Infinity';
+;;       }
+
+;;       if (Math.abs(a) < Complex['EPSILON']) {
+;;         a = 0;
+;;       }
+
+;;       if (Math.abs(b) < Complex['EPSILON']) {
+;;         b = 0;
+;;       }
+
+;;       // If is real number
+;;       if (b === 0) {
+;;         return ret + a;
+;;       }
+
+;;       if (a !== 0) {
+;;         ret += a;
+;;         ret += " ";
+;;         if (b < 0) {
+;;           b = -b;
+;;           ret += "-";
+;;         } else {
+;;           ret += "+";
+;;         }
+;;         ret += " ";
+;;       } else if (b < 0) {
+;;         b = -b;
+;;         ret += "-";
+;;       }
+
+;;       if (1 !== b) { // b is the absolute imaginary part
+;;         ret += b;
+;;       }
+;;       return ret + "i";
+;;     },
+
+(defn to-vector
+  "Returns the actual number as a vector"
+  [^Complex z]
+  [(.-re z) (.-im z)])
+
+(defn value-of [z])
+;;     /**
+;;      * Returns the actual real value of the current object
+;;      *
+;;      * @returns {number|null}
+;;      */
+;;     'valueOf': function() {
+
+;;       if (this['im'] === 0) {
+;;         return this['re'];
+;;       }
+;;       return null;
+;;     },
+
+(defn is-nan [z])
+;;     /**
+;;      * Determines whether a complex number is not on the Riemann sphere.
+;;      *
+;;      * @returns {boolean}
+;;      */
+;;     'isNaN': function() {
+;;       return isNaN(this['re']) || isNaN(this['im']);
+;;     },
+
+(defn is-zero [z])
+;;     /**
+;;      * Determines whether or not a complex number is at the zero pole of the
+;;      * Riemann sphere.
+;;      *
+;;      * @returns {boolean}
+;;      */
+;;     'isZero': function() {
+;;       return this['im'] === 0 && this['re'] === 0;
+;;     },
+
+(defn is-finite [z])
+;;     /**
+;;      * Determines whether a complex number is not at the infinity pole of the
+;;      * Riemann sphere.
+;;      *
+;;      * @returns {boolean}
+;;      */
+;;     'isFinite': function() {
+;;       return isFinite(this['re']) && isFinite(this['im']);
+;;     },
+
+(defn is-infinite
+  "Determines whether or not a complex number is at the infinity pole of the Riemann sphere."
+  [z]
+  (not
+   (or (is-nan z)
+       (is-finite z))))

--- a/src/emmy/complex/impl.cljc
+++ b/src/emmy/complex/impl.cljc
@@ -81,14 +81,12 @@
           (and (v/= r (.-re w))
                (v/= i (.-im w)))
 
-          (sequential? w)
-          (and (= (count w) 2)
-               (v/= r (nth w 0))
-               (v/= i (nth w 1)))
+          (v/real? w)
+          (and (g/zero? i)
+               (v/= r w))
 
-          :else (and (v/real? w)
-                     (g/zero? i)
-                     (v/= r w)))))
+          ;; Defer to `v/=` to support quaternion, octonion equality etc.
+          :else (v/= z w))))
 
 (defn zero?
   "Determines whether or not a complex number is at the zero pole of the

--- a/src/emmy/complex/impl.cljc
+++ b/src/emmy/complex/impl.cljc
@@ -79,7 +79,7 @@
   (or (u/nan? (.-re z))
       (u/nan? (.-im z))))
 
-(def ^:private cos-1-square-terms
+(def ^:no-doc cos-1-square-terms
   "For the origin of these constants, see the related material
    in [[emmy.series-test/cos-1-square-terms]]."
   [4.779477332387385E-14 -1.147074559772972E-11 2.08767569878681E-9 -2.755731922398589E-7
@@ -135,17 +135,27 @@
                        b (g// b 2)]
                    (g/+ LN2 (g// (g/log (g/+ (g/* a a) (g/* b b))) 2)))))))
 
-(let [complex-re #"([+-]?\d+(\.\d*)?([Ee][+-]?\d+)?)(\s?([+-])\s?(\d+(\.\d*)?([Ee][+-]?\d+)?)[Ii])?"]
-  (defn parse
-    "Parse a complex number. We expect one or two floating point numbers.
-    If two, they must be separated by a sign (perhaps surrounded by at most
-    one space, the second number followed by I or i. Example: 1.2-3.4i)"
-    [s]
-    (if-let [[_ re re-frac re-expt _ sign im im-frac im-expt] (re-matches complex-re s)]
-      (->Complex ((if (or re-frac re-expt) u/parse-double u/parse-int) re)
-                 (* (if (= sign "-") -1 1)
-                    (if im ((if (or im-frac im-expt) u/parse-double u/parse-int) im) 0)))
-      (throw (ex-info "invalid complex number" {:input s})))))
+(def ^:private
+  complex-re
+  "Regular expression used to parse complex numbers"
+  #"([+-]?\d+(\.\d*)?([Ee][+-]?\d+)?)(\s?([+-])?\s?([+-]?\d+(\.\d*)?([Ee][+-]?\d+)?)[Ii])?")
+
+(comment
+  (re-matches complex-re "-1.2e3 + -4.5e6I")
+  (re-matches complex-re "0+3i")
+
+  )
+
+(defn parse
+  "Parse a complex number. We expect one or two floating point numbers.
+  If two, they must be separated by a sign (perhaps surrounded by at most
+  one space, the second number followed by I or i. Example: 1.2-3.4i)"
+  [s]
+  (if-let [[_ re re-frac re-expt _ sign im im-frac im-expt] (re-matches complex-re s)]
+    (->Complex ((if (or re-frac re-expt) u/parse-double u/parse-int) re)
+               (* (if (= sign "-") -1 1)
+                  (if im ((if (or im-frac im-expt) u/parse-double u/parse-int) im) 0)))
+    (throw (ex-info "invalid complex number" {:input s}))))
 
 (defn add
   "Compute the complex sum."
@@ -211,7 +221,6 @@
                   (->Complex (g// (g/+ a (g/* b x)) t)
                              (g// (g/- b (g/* a x)) t)))))))
 
-
 (defn pow
   "Calculate the power of two complex numbers. 0 to any power is
    zero, unless that power has an imaginary component, in which case NaN.
@@ -270,7 +279,7 @@
   [^Complex z]
   (let [a (.-re z)
         b (.-im z)]
-   (->Complex (log-hypot z) (g/atan b a))))
+    (->Complex (log-hypot z) (g/atan b a))))
 
 (defn arg
   "Calculate the angle of the complex number."
@@ -455,7 +464,6 @@
         d (g/- (g/cosh a) (g/cos b))]
     (->Complex (g// (g/sinh a) d)
                (g// (g/negate (g/sin b)) d))))
-
 
 (defn csch
   "Compute the complex hyperbolic cosecant."

--- a/src/emmy/util.cljc
+++ b/src/emmy/util.cljc
@@ -178,3 +178,23 @@
 
 (def sqrt-machine-epsilon
   (Math/sqrt machine-epsilon))
+
+(defn parse-int
+  [s]
+  #?(:clj (Integer/parseInt s)
+     :cljs (. js/Number parseInt s)))
+
+(defn parse-double
+  [s]
+  #?(:clj (Double/parseDouble s)
+     :cljs (. js/Number parseFloat s)))
+
+(defn nan?
+  [x]
+  #?(:clj (Double/isNaN x)
+     :cljs (. js/Number isNaN x)))
+
+(defn finite?
+  [x]
+  #?(:clj (Double/isFinite x)
+     :cljs (. js/Number isFinite x)))

--- a/src/emmy/util.cljc
+++ b/src/emmy/util.cljc
@@ -193,8 +193,3 @@
   [x]
   #?(:clj (Double/isNaN x)
      :cljs (. js/Number isNaN x)))
-
-(defn finite?
-  [x]
-  #?(:clj (Double/isFinite x)
-     :cljs (. js/Number isFinite x)))

--- a/src/emmy/util.cljc
+++ b/src/emmy/util.cljc
@@ -2,7 +2,7 @@
 
 (ns emmy.util
   "Shared utilities between clojure and clojurescript."
-  (:refer-clojure :exclude [bigint biginteger double long int uuid #?(:cljs parse-double)])
+  (:refer-clojure :exclude [bigint biginteger double long int uuid parse-double])
   (:require #?(:clj [clojure.core :as core])
             #?(:clj [clojure.math.numeric-tower :as nt])
             #?(:cljs goog.math.Integer)

--- a/src/emmy/util.cljc
+++ b/src/emmy/util.cljc
@@ -2,7 +2,7 @@
 
 (ns emmy.util
   "Shared utilities between clojure and clojurescript."
-  (:refer-clojure :exclude [bigint biginteger double long int uuid])
+  (:refer-clojure :exclude [bigint biginteger double long int uuid #?(:cljs parse-double)])
   (:require #?(:clj [clojure.core :as core])
             #?(:clj [clojure.math.numeric-tower :as nt])
             #?(:cljs goog.math.Integer)

--- a/src/emmy/value.cljc
+++ b/src/emmy/value.cljc
@@ -23,6 +23,8 @@
 (defprotocol Numerical
   (^boolean numerical? [_]))
 
+(defprotocol INumericTower)
+
 (extend-protocol Numerical
   #?(:clj Object :cljs default)
   (numerical? [_] false))
@@ -90,13 +92,13 @@
   [x]
   #?(:clj
      (or (instance? Number x)
-         (core/= (kind x) :emmy.complex/complex))
+         (instance? emmy.value.INumericTower x))
      :cljs (or (cljs.core/number? x)
                (core/= "bigint" (goog/typeOf x))
                (instance? Fraction x)
                (instance? goog.math.Integer x)
                (instance? goog.math.Long x)
-               (core/= (kind x) :emmy.complex/complex))))
+               (instance? emmy.value.INumericTower x))))
 
 ;; `::scalar` is a thing that symbolic expressions AND actual numbers both
 ;; derive from.

--- a/src/emmy/value.cljc
+++ b/src/emmy/value.cljc
@@ -98,7 +98,7 @@
                (instance? Fraction x)
                (instance? goog.math.Integer x)
                (instance? goog.math.Long x)
-               (instance? emmy.value.INumericTower x))))
+               (satisfies? emmy.value.INumericTower x))))
 
 ;; `::scalar` is a thing that symbolic expressions AND actual numbers both
 ;; derive from.

--- a/src/emmy/value.cljc
+++ b/src/emmy/value.cljc
@@ -9,8 +9,7 @@
   for a detailed discussion of how to use and extend the generic operations
   defined in [[emmy.generic]] and [[emmy.value]]."
   (:refer-clojure :exclude [zero? number? = compare])
-  (:require #?@(:cljs [["complex.js" :as Complex]
-                       ["fraction.js/bigfraction.js" :as Fraction]
+  (:require #?@(:cljs [["fraction.js/bigfraction.js" :as Fraction]
                        [emmy.util :as u]
                        [goog.array :as garray]
                        [goog.object :as gobject]
@@ -19,8 +18,7 @@
             [clojure.core :as core])
   #?(:clj
      (:import
-      (clojure.lang BigInt Sequential)
-      (org.apache.commons.math3.complex Complex))))
+      (clojure.lang BigInt Sequential))))
 
 (defprotocol Numerical
   (^boolean numerical? [_]))
@@ -92,13 +90,13 @@
   [x]
   #?(:clj
      (or (instance? Number x)
-         (instance? Complex x))
+         (core/= (kind x) :emmy.complex/complex))
      :cljs (or (cljs.core/number? x)
                (core/= "bigint" (goog/typeOf x))
                (instance? Fraction x)
                (instance? goog.math.Integer x)
                (instance? goog.math.Long x)
-               (instance? Complex x))))
+               (core/= (kind x) :emmy.complex/complex))))
 
 ;; `::scalar` is a thing that symbolic expressions AND actual numbers both
 ;; derive from.

--- a/test/emmy/abstract/number_test.cljc
+++ b/test/emmy/abstract/number_test.cljc
@@ -712,7 +712,7 @@
                 (is (v/= sym (g/make-polar sym n))
                     "an exact zero returns the symbolic radius.")
                 (is (= `(~'* ~sym (~'+ (~'cos ~(g/freeze n))
-                                   (~'* (~'complex 0.0 1.0)
+                                   (~'* (~'complex 0 1)
                                     (~'sin ~(g/freeze n)))))
                        (g/freeze
                         (g/make-polar sym n)))
@@ -757,8 +757,8 @@
                    (g/magnitude z))))
 
   (testing "dot-product"
-    (is (= '(+ (* 0.5 x (conjugate y))
-               (* 0.5 y (conjugate x)))
+    (is (= '(+ (* (/ 1 2) x (conjugate y))
+               (* (/ 1 2) y (conjugate x)))
            (g/freeze
             (g/simplify
              (g/dot-product 'x 'y)))))

--- a/test/emmy/calculus/derivative_test.cljc
+++ b/test/emmy/calculus/derivative_test.cljc
@@ -368,7 +368,7 @@
 
 (deftest complex-derivatives
   (let [f (fn [z] (* c/I (sin (* c/I z))))]
-    (is (= '(* -1.0 (cosh z))
+    (is (= '(* -1 (cosh z))
            (simplify
             ((D f) 'z))))))
 

--- a/test/emmy/collection_test.cljc
+++ b/test/emmy/collection_test.cljc
@@ -128,15 +128,15 @@
             (is (= m (g/make-rectangular m {}))
                 "make-rectangular with no imaginary parts is identity.")
 
-            (is (ish? (g/* m I)
-                      (g/make-rectangular {} m))
-                "every entry turns turns imaginary!")
+            (is (v/= (g/* m I)
+                     (g/make-rectangular {} m))
+                "every entry turns imaginary!")
 
             (is (= m (g/make-polar m {}))
                 "make-polar with no angles is identity.")
 
-            (is (ish? (g/zero-like m)
-                      (g/make-polar {} m))
+            (is (v/= (g/zero-like m)
+                     (g/make-polar {} m))
                 "if all angles comes from m, but every radius is 0, then the
                 resulting entries will be zero.")
 
@@ -145,7 +145,7 @@
 
             (is (ish? (g/zero-like m)
                       (g/imag-part m))
-                "imag-part on all real is zeor-like.")
+                "imag-part on all real is zero-like.")
 
             (is (ish? m (g/imag-part
                          (g/make-rectangular m m)))

--- a/test/emmy/complex_test.cljc
+++ b/test/emmy/complex_test.cljc
@@ -5,14 +5,14 @@
             [clojure.test :refer [deftest is testing]]
             [com.gfredericks.test.chuck.clojure-test :refer [checking]]
             [emmy.complex :as c]
+            [emmy.complex.impl :as ci]
             [emmy.generators :as sg]
             [emmy.generic :as g]
             [emmy.generic-test :as gt]
             [emmy.laws :as l]
             [emmy.numbers]
             [emmy.value :as v]
-            [same.core :refer [ish? with-comparator]]
-            [clojure.zip :as z]))
+            [same.core :refer [ish? with-comparator]]))
 
 (defn ^:private near [w z]
   (< (g/abs (g/- w z)) 1e-10))
@@ -526,7 +526,28 @@
   (testing "some corner cases"
     (is (g/infinite? (g/atan c/I)))
     (is (g/infinite? (g/atan (g/negate c/I))))
-    (is (g/infinite? (g/asech c/ZERO)))))
+    (is (g/infinite? (g/asec c/ZERO)))
+    (is (g/infinite? (g/acsc c/ZERO)))
+    (is (near (c/complex (g// Math/PI 2)) (g/acot c/ZERO)))
+    (is (g/infinite? (g/asech c/ZERO)))
+    (is (g/infinite? (g/acsch c/ZERO)))
+    (is (ci/nan? (g// c/ZERO c/ZERO)))
+    (is (ci/nan? (g// ci/INFINITY ci/INFINITY)))
+    (is (g/infinite? (g// ci/INFINITY c/ZERO)))
+
+    ;; In Emmy a zero in a `*` expression annihilates everything,
+    ;; preventing this particular behavior from being observed.
+    (is (ci/nan? (ci/mul c/ZERO ci/INFINITY)))
+    (is (ci/nan? (ci/mul ci/INFINITY c/ZERO)))
+    ;; In contrast:
+    (is (g/zero? (g/* c/ZERO ci/INFINITY)))
+    (is (g/zero? (g/* ci/INFINITY c/ZERO)))
+
+    (is (g/infinite? (g/* c/I ci/INFINITY)))
+    (is (g/infinite? (g/* ci/INFINITY c/I)))
+    (is (g/zero? (g/expt c/ZERO c/ONE)))
+    (is (ci/nan? (g/expt c/ZERO c/I)))))
+
 
 (deftest promotions-from-real
   (is (= (c/complex 0 1) (g/sqrt -1)))

--- a/test/emmy/complex_test.cljc
+++ b/test/emmy/complex_test.cljc
@@ -566,6 +566,8 @@
     (is (ci/nan? (g// c/ZERO c/ZERO)))
     (is (ci/nan? (g// ci/INFINITY ci/INFINITY)))
     (is (g/infinite? (g// ci/INFINITY c/ZERO)))
+    (is (g/infinite? (g/invert c/ZERO)))
+    (is (g/zero? (g/invert ci/INFINITY)))
 
     ;; In Emmy a zero in a `*` expression annihilates everything,
     ;; preventing this particular behavior from being observed.

--- a/test/emmy/complex_test.cljc
+++ b/test/emmy/complex_test.cljc
@@ -2,7 +2,7 @@
 
 (ns emmy.complex-test
   (:require #?(:cljs [cljs.reader :refer [read-string]])
-            [clojure.test :refer [is deftest testing]]
+            [clojure.test :refer [deftest is testing]]
             [com.gfredericks.test.chuck.clojure-test :refer [checking]]
             [emmy.complex :as c]
             [emmy.generators :as sg]
@@ -11,24 +11,33 @@
             [emmy.laws :as l]
             [emmy.numbers]
             [emmy.value :as v]
-            [same.core :refer [ish? with-comparator]]))
+            [same.core :refer [ish? with-comparator]]
+            [clojure.zip :as z]))
 
 (defn ^:private near [w z]
   (< (g/abs (g/- w z)) 1e-10))
 
+(defn right-half-plane
+  "If z is not in the right half plane, move it there by rotating it 180°
+  (i.e., multiply by -1). This is used for inverse identity tests where the
+  principal value of the inverse function is the right half-plane."
+  [z]
+  (if (g/negative? (c/real z))
+    (g/negate z)
+    z))
+
 (deftest complex-literal
   (testing "complex constructor-as-parser can round-trip Complex instances. These
   show up as code snippets when you call `read-string` directly, and aren't evaluated
-  into Clojure. The fork in the test here captures the different behavior that will
-  appear in evaluated Clojure, vs self-hosted ClojureScript."
-    (is (= `(emmy.complex/complex [1 2])
+  into Clojure."
+    (is (= `(c/complex [1 2])
 
            ;; string input:
-           (read-string {:readers {'emmy/complex c/complex}}
+           (read-string {:readers {'emmy/complex c/parse-complex}}
                         (pr-str #emmy/complex "1 + 2i"))
 
            ;; vector input:
-           (read-string {:readers {'emmy/complex c/complex}}
+           (read-string {:readers {'emmy/complex c/parse-complex}}
                         (pr-str #emmy/complex [1 2]))))
 
     (checking "complex constructor can handle strings OR direct inputs" 100
@@ -298,6 +307,15 @@
       (is (near (c/complex 27) (g/cube (c/complex 3))))
       (is (near (c/complex -27) (g/cube (c/complex -3)))))
 
+    (testing "sqrt/square are mutually inverse"
+      ;; principal value for sqrt: right half-plane. If the value is in
+      ;; the left half-plane, make it principal by rotating 180°.
+
+      (checking "sqrt ∘ square = id" 100 [z (sg/reasonable-complex)]
+                (is (near (right-half-plane z) (g/sqrt (g/square z)))))
+      (checking "square ∘ sqrt = id" 100 [z (sg/reasonable-complex)]
+                (is (near z (g/square (g/sqrt z))))))
+
     (testing "sqrt"
       (is (near (c/complex 10 10) (g/sqrt (g/mul c/I 200)))))
 
@@ -369,67 +387,146 @@
                   (check gaussian-l (g/real-part gaussian-r)))))))
 
 (deftest trig-tests
-  (testing "sin"
-    (is (near (g/sin (c/complex 10))
-              (Math/sin 10))))
+  ;; Mathematica:
+  ;;   fns = {Sin, Cos, ..., ArcCoth}
+  ;;   z = 0.1 + 0.2 I
+  ;;   Table[{f, NumberForm[f[z], 12]}, {f, fns}]
+  ;; The results of that expression were massaged into the
+  ;; Clojure-readable form below.
+  (testing "one particular value"
+    (let [z (c/complex 0.1 0.2)
+          expected {:Sin #emmy/complex "0.101836749421+0.200330161149I"
+                    :Cos #emmy/complex "1.0149706707-0.0201000610277I"
+                    :Tan #emmy/complex "0.0963881308565+0.19928415106I"
+                    :Csc #emmy/complex "2.01645361897-3.96670632883I"
+                    :Sec #emmy/complex "0.984863898536+0.0195038389147I"
+                    :Cot #emmy/complex "1.9669102428-4.06662142386I"
+                    :Sinh #emmy/complex "0.0981700839054+0.199663505514I"
+                    :Cosh #emmy/complex "0.984970995703+0.0199000611944I"
+                    :Tanh #emmy/complex "0.103721150028+0.200614484227I"
+                    :Csch #emmy/complex "1.98311860447-4.03337143727I"
+                    :Sech #emmy/complex "1.01484407288-0.0205036079653I"
+                    :Coth #emmy/complex "2.03357864486-3.93328969902I"
+                    :ArcSin #emmy/complex "0.0981975111335+0.19963938539I"
+                    :ArcCos #emmy/complex "1.47259881566-0.19963938539I"
+                    :ArcTan #emmy/complex "0.103748113218+0.200586618131I"
+                    :ArcCsc #emmy/complex "0.453870209963-2.19857302792I"
+                    :ArcSec #emmy/complex "1.11692611683+2.19857302792I"
+                    :ArcCot #emmy/complex "1.46704821358-0.200586618131I"
+                    :ArcSinh #emmy/complex "0.10186391598+0.200303571099I"
+                    :ArcCosh #emmy/complex "0.19963938539+1.47259881566I"
+                    :ArcTanh #emmy/complex "0.096415620203+0.199261222833I"
+                    :ArcCsch #emmy/complex "2.18358521656-1.09692154883I"
+                    :ArcSech #emmy/complex "2.19857302792-1.11692611683I"
+                    :ArcCoth #emmy/complex "0.096415620203-1.37153510396I"}]
+      (is (near (:Sin expected) (g/sin z)))
+      (is (near (:Cos expected) (g/cos z)))
+      (is (near (:Tan expected) (g/tan z)))
+      (is (near (:Csc expected) (g/csc z)))
+      (is (near (:Sec expected) (g/sec z)))
+      (is (near (:Cot expected) (g/cot z)))
+      (is (near (:Sinh expected) (g/sinh z)))
+      (is (near (:Cosh expected) (g/cosh z)))
+      (is (near (:Tanh expected) (g/tanh z)))
+      (is (near (:Csch expected) (g/csch z)))
+      (is (near (:Sech expected) (g/sech z)))
+      (is (near (:Coth expected) (g/coth z)))
+      (is (near (:ArcSin expected) (g/asin z)))
+      (is (near (:ArcCos expected) (g/acos z)))
+      (is (near (:ArcTan expected) (g/atan z)))
+      (is (near (:ArcCsc expected) (g/acsc z)))
+      (is (near (:ArcSec expected) (g/asec z)))
+      (is (near (:ArcCot expected) (g/acot z)))
+      (is (near (:ArcSinh expected) (g/asinh z)))
+      (is (near (:ArcCosh expected) (g/acosh z)))
+      (is (near (:ArcTanh expected) (g/atanh z)))
+      (is (near (:ArcCsch expected) (g/acsch z)))
+      (is (near (:ArcSech expected) (g/asech z)))
+      (is (near (:ArcCoth expected) (g/acoth z)))))
+  (testing "reciprocal identities"
+    (let [near-enough (fn [w z] (< (g/abs (g/- z w)) 1e-6))]
+      ;; we relax `near` a bit because taking reciprocals moves
+      ;; some of the significance to the left of the decimal point
+      (checking "1/sin = csc" 100 [z (sg/reasonable-complex)]
+                (is (near-enough (g/invert (g/sin z)) (g/csc z))))
+      (checking "1/csc = sin" 100 [z (sg/reasonable-complex)]
+                (is (near-enough (g/invert (g/csc z)) (g/sin z))))
+      (checking "1/cos = sec" 100 [z (sg/reasonable-complex)]
+                (is (near-enough (g/invert (g/cos z)) (g/sec z))))
+      (checking "1/sec = cos" 100 [z (sg/reasonable-complex)]
+                (is (near-enough (g/invert (g/sec z)) (g/cos z))))
+      (checking "1/tan = cot" 100 [z (sg/reasonable-complex)]
+                (is (near-enough (g/invert (g/tan z)) (g/cot z))))
+      (checking "1/cot = tan" 100 [z (sg/reasonable-complex)]
+                (is (near-enough (g/invert (g/cot z)) (g/tan z))))
 
-  (testing "cos"
-    (is (near (g/cos (c/complex 10))
-              (Math/cos 10))))
+      (checking "1/sinh = csch" 100 [z (sg/reasonable-complex)]
+                (is (near-enough (g/invert (g/sinh z)) (g/csch z))))
+      (checking "1/csch = sinh" 100 [z (sg/reasonable-complex)]
+                (is (near-enough (g/invert (g/csch z)) (g/sinh z))))
+      (checking "1/cosh = sech" 100 [z (sg/reasonable-complex)]
+                (is (near-enough (g/invert (g/cosh z)) (g/sech z))))
+      (checking "1/sech = cosh" 100 [z (sg/reasonable-complex)]
+                (is (near-enough (g/invert (g/sech z)) (g/cosh z))))
+      (checking "1/tanh = coth" 100 [z (sg/reasonable-complex)]
+                (is (near-enough (g/invert (g/tanh z)) (g/coth z))))
+      (checking "1/coth = tanh" 100 [z (sg/reasonable-complex)]
+                (is (near-enough (g/invert (g/coth z)) (g/tanh z))))))
+  (testing "inverse identities"
+    (checking "asin ∘ sin = id" 100 [z (sg/reasonable-complex)]
+              (is (near z (g/asin (g/sin z)))))
+    (checking "sin ∘ asin = id" 100 [z (sg/reasonable-complex)]
+              (is (near z (g/sin (g/asin z)))))
+    (checking "acos ∘ cos = id" 100 [z (sg/reasonable-complex)]
+              (is (near (right-half-plane z) (g/acos (g/cos z)))))
+    (checking "cos ∘ acos = id" 100 [z (sg/reasonable-complex)]
+              (is (near z (g/cos (g/acos z)))))
+    (checking "atan ∘ tan = id" 100 [z (sg/reasonable-complex)]
+              (is (near z (g/atan (g/tan z)))))
+    (checking "tan ∘ atan = id" 100 [z (sg/reasonable-complex)]
+              (is (near z (g/tan (g/atan z)))))
+    (checking "acsc ∘ csc = id" 100 [z (sg/reasonable-complex)]
+              (is (near z (g/acsc (g/csc z)))))
+    (checking "csc ∘ acsc = id" 100 [z (sg/reasonable-complex)]
+              (is (near z (g/csc (g/acsc z)))))
+    (checking "asec ∘ sec = id" 100 [z (sg/reasonable-complex)]
+              (is (near (right-half-plane z) (g/asec (g/sec z)))))
+    (checking "sec ∘ asec = id" 100 [z (sg/reasonable-complex)]
+              (is (near z (g/sec (g/asec z)))))
+    (checking "acot ∘ cot = id" 100 [z (sg/reasonable-complex)]
+              (is (near z (g/acot (g/cot z)))))
+    (checking "cot ∘ acot = id" 100 [z (sg/reasonable-complex)]
+              (is (near z (g/cot (g/acot z)))))
 
-  (testing "tan"
-    (is (near (g/tan (c/complex 10))
-              (Math/tan 10))))
+    (checking "asinh ∘ sinh = id" 100 [z (sg/reasonable-complex)]
+              (is (near z (g/asinh (g/sinh z)))))
+    (checking "sinh ∘ asinh = id" 100 [z (sg/reasonable-complex)]
+              (is (near z (g/sinh (g/asinh z)))))
+    (checking "acosh ∘ cosh = id" 100 [z (sg/reasonable-complex)]
+              (is (near (right-half-plane z) (g/acosh (g/cosh z)))))
+    (checking "cosh ∘ acosh = id" 100 [z (sg/reasonable-complex)]
+              (is (near z (g/cosh (g/acosh z)))))
+    (checking "atanh ∘ tanh = id" 100 [z (sg/reasonable-complex)]
+              (is (near z (g/atanh (g/tanh z)))))
+    (checking "tanh ∘ atanh = id" 100 [z (sg/reasonable-complex)]
+              (is (near z (g/tanh (g/atanh z)))))
+    (checking "acsch ∘ csch = id" 100 [z (sg/reasonable-complex)]
+              (is (near z (g/acsch (g/csch z)))))
+    (checking "csch ∘ acsch = id" 100 [z (sg/reasonable-complex)]
+              (is (near z (g/csch (g/acsch z)))))
+    (checking "asech ∘ sech = id" 100 [z (sg/reasonable-complex)]
+              (is (near (right-half-plane z) (g/asech (g/sech z)))))
+    (checking "sech ∘ asech = id" 100 [z (sg/reasonable-complex)]
+              (is (near z (g/sech (g/asech z)))))
+    (checking "acoth ∘ coth = id" 100 [z (sg/reasonable-complex)]
+              (is (near z (g/acoth (g/coth z)))))
+    (checking "coth ∘ acoth = id" 100 [z (sg/reasonable-complex)]
+              (is (near z (g/coth (g/acoth z))))))
 
-  (testing "asin"
-    (is (near (g/asin (c/complex 1.1))
-              (c/complex 1.57079632679489 -0.443568254385115))))
-
-  (testing "acos"
-    (is (near (g/acos (c/complex 1.1))
-              (c/complex 0 0.4435682543851153))))
-
-  (testing "atan"
-    (is (near (g/atan (c/complex 1.1))
-              (c/complex 0.8329812666744317 0.0))))
-
-  (let [z (c/complex 3 4)]
-    (testing "cot"
-      (is (near (g/invert (g/tan z))
-                (g/cot z))))
-
-    (testing "cosh"
-      (is (near (c/complex -6.5806630406 -7.5815527427)
-                (g/cosh z))))
-
-    (testing "sinh"
-      (is (near (c/complex -6.5481200409 -7.6192317203)
-                (g/sinh z))))
-
-    (testing "tanh"
-      (is (near (g/div (g/sinh z) (g/cosh z))
-                (g/tanh z))))
-
-    (testing "sec"
-      (is (near (g/invert (g/cos z))
-                (g/sec z))))
-
-    (testing "csc"
-      (is (near (g/invert (g/sin z))
-                (g/csc z))))
-
-    (testing "sech"
-      (is (near (g/invert (g/cosh z))
-                (g/sech z))))
-
-    (testing "acosh"
-      (is (near z (g/cosh (g/acosh z)))))
-
-    (testing "asinh"
-      (is (near z (g/sinh (g/asinh z)))))
-
-    (testing "atanh"
-      (is (near z (g/tanh (g/atanh z)))))))
+  (testing "some corner cases"
+    (is (g/infinite? (g/atan c/I)))
+    (is (g/infinite? (g/atan (g/negate c/I))))
+    (is (g/infinite? (g/asech c/ZERO)))))
 
 (deftest promotions-from-real
   (is (= (c/complex 0 1) (g/sqrt -1)))

--- a/test/emmy/complex_test.cljc
+++ b/test/emmy/complex_test.cljc
@@ -597,4 +597,7 @@
                 (is (ish? (g/real-part z)
                           (g/real-part rt)))
                 (is (ish? (g/imag-part z)
-                          (g/imag-part rt)))))))
+                          (g/imag-part rt))))))
+
+  (checking "exp-1" 100 [z (sg/reasonable-complex)]
+            (is (near (g/- (g/exp z) 1) (ci/exp-1 z)))))

--- a/test/emmy/generators.cljc
+++ b/test/emmy/generators.cljc
@@ -71,6 +71,15 @@
                               :min excluded-upper
                               :max max})])))
 
+(defn reasonable-complex
+  "A complex number in the unit square, bounded away from the axes,
+  in order to avoid branch points"
+  []
+  (let [bounds {:min -1 :max 1 :excluded-lower -1e-3 :excluded-upper 1e-3}]
+    (gen/let [re (reasonable-double bounds)
+              im (reasonable-double bounds)]
+      (c/complex re im))))
+
 (defn inexact-double
   ([] (inexact-double {}))
   ([opts]

--- a/test/emmy/generators.cljc
+++ b/test/emmy/generators.cljc
@@ -387,10 +387,10 @@
   In CLJS, `this` can be `js/BigInt`, `google.math.Long`, `goog.math.Real`,
   `Fraction` or any of the other types in the numeric tower."
   [this that]
-  (cond (c/complex? that) (and (si/*comparator* 0.0 (g/imag-part that))
+  (cond (c/complex? that) (and (si/*comparator* 0.0 (u/double (g/imag-part that)))
                                (si/*comparator*
                                 (u/double this)
-                                (g/real-part that)))
+                                (u/double (g/real-part that))))
         (v/real? that)    (si/*comparator*
                            (u/double this)
                            (u/double that))
@@ -426,18 +426,18 @@
   Complex
   (ish [this that]
     (cond (c/complex? that)
-          (and (si/*comparator* (c/real this)
-                                (c/real that))
-               (si/*comparator* (c/imaginary this)
-                                (c/imaginary that)))
+          (and (si/*comparator* (u/double (c/real this))
+                                (u/double (c/real that)))
+               (si/*comparator* (u/double (c/imaginary this))
+                                (u/double (c/imaginary that))))
 
           (quat/quaternion? that)
           (si/ish that this)
 
           (v/real? that)
-          (and (si/*comparator* 0.0 (c/imaginary this))
+          (and (si/*comparator* 0.0 (u/double (c/imaginary this)))
                (si/*comparator*
-                (c/real this) (u/double that)))
+                (u/double (c/real this)) (u/double that)))
           :else (v/= this that)))
 
   Quaternion

--- a/test/emmy/generators.cljc
+++ b/test/emmy/generators.cljc
@@ -6,6 +6,7 @@
   (:require [clojure.core :as core]
             [clojure.test.check.generators :as gen]
             [emmy.complex :as c]
+            #?(:cljs [emmy.complex.impl :refer [Complex]])
             [emmy.differential :as d]
             [emmy.generic :as g]
             [emmy.matrix :as m]
@@ -27,7 +28,7 @@
      (:import (clojure.lang Symbol)
               (emmy.structure Structure)
               (emmy.quaternion Quaternion)
-              (org.apache.commons.math3.complex Complex))))
+              (emmy.complex.impl Complex))))
 
 (def bigint
   "js/BigInt in cljs, clojure.lang.BigInt in clj."
@@ -413,7 +414,7 @@
        Number
        (ish [this that] (eq-delegate this that))])
 
-  #?(:cljs c/complextype :clj Complex)
+  Complex
   (ish [this that]
     (cond (c/complex? that)
           (and (si/*comparator* (c/real this)

--- a/test/emmy/quaternion_test.cljc
+++ b/test/emmy/quaternion_test.cljc
@@ -254,9 +254,9 @@
               (is (v/= r (q/make r)) "real == quaternion")
               (is (v/= (q/make r) r) "quaternion == real")
 
-              (is (ish? #emmy/complex [r i] (q/make r i 0 0))
+              (is (ish? (sc/complex r i) (q/make r i 0 0))
                   "complex == quaternion")
-              (is (ish? (q/make r i 0 0) #emmy/complex [r i])
+              (is (ish? (q/make r i 0 0) (sc/complex r i))
                   "quaternion == complex")
 
               (is (v/= v (q/make v)) "vector == quaternion")
@@ -285,7 +285,7 @@
                   real component and imaginary vector.")
 
               (is (ish? (q/make [r i 0 0])
-                        (q/make #emmy/complex [r i]))
+                        (q/make (sc/complex r i)))
                   "make can properly unpack complex numbers")
 
               (is (= (q/make v)

--- a/test/emmy/quaternion_test.cljc
+++ b/test/emmy/quaternion_test.cljc
@@ -254,9 +254,9 @@
               (is (v/= r (q/make r)) "real == quaternion")
               (is (v/= (q/make r) r) "quaternion == real")
 
-              (is (ish? (sc/complex r i) (q/make r i 0 0))
+              (is (v/= (sc/complex r i) (q/make r i 0 0))
                   "complex == quaternion")
-              (is (ish? (q/make r i 0 0) (sc/complex r i))
+              (is (v/= (q/make r i 0 0) (sc/complex r i))
                   "quaternion == complex")
 
               (is (v/= v (q/make v)) "vector == quaternion")
@@ -361,8 +361,8 @@
                 (is (ish? (g/make-polar mag angle)
                           (q/complex-1 q)))
 
-                (is (ish? (g/make-rectangular j k)
-                          (q/complex-2 q)))))))
+                (is (v/= (g/make-rectangular j k)
+                         (q/complex-2 q)))))))
 
 (deftest arithmetic-tests
   (testing "Quaternions form a skew field, i.e., a division ring."

--- a/test/emmy/ratio_test.cljc
+++ b/test/emmy/ratio_test.cljc
@@ -141,8 +141,8 @@
            (g/sqrt #emmy/ratio 9/4))
         "Ratios should stay exact if the numerator and denominator are exact.")
 
-    (is (= #emmy/complex "0+1.5i"
-           (g/sqrt #emmy/ratio -9/4))
+    (is (= #emmy/complex [0 #emmy/ratio 3/2]
+            (g/sqrt #emmy/ratio -9/4))
         "sqrt of a negative returns a complex number.")
 
     (is (= #emmy/ratio 13/40

--- a/test/emmy/series_test.cljc
+++ b/test/emmy/series_test.cljc
@@ -5,6 +5,7 @@
             [clojure.test.check.generators :as gen]
             [com.gfredericks.test.chuck.clojure-test :refer [checking]]
             [emmy.calculus.derivative]
+            [emmy.complex.impl :as ci]
             [emmy.function :as f]
             [emmy.generators :as sg]
             [emmy.generic :as g]
@@ -659,26 +660,17 @@
   ;; => (0 0 -1/2 0 1/24 0 -1/720 0 1/40320 0)
   ;; From this we can see that we may regard the expansion as a series in x^2, with a
   ;; zero constant term.
-    (let [cosm1-series (->> (g/- s/cos-series 1)
-                            (remove g/zero?)  ;; eliminate the useless zero coefficients of the odd powers of x
-                            (map double)      ;; we don't want the rational arithmetic to survive
-                            (take 8)          ;; the filtered series now has coefficients for x^2, x^4 ... x^16
-                            (cons 0.)         ;; cons 0 and reverse facilitate evaluation with Horner's method
-                            (reverse))]
-      (let [near (v/within 1e-10)
-            horner-eval (fn [s x] (reduce (fn [a b] (+ (* a x) b)) s))]
-        (is (every? #(near 0 %) (map - [4.779477332387385E-14
-                                        -1.147074559772972E-11
-                                        2.08767569878681E-9
-                                        -2.755731922398589E-7
-                                        2.48015873015873E-5
-                                        -0.001388888888888889
-                                        0.04166666666666667
-                                        -0.5
-                                        0.0]
-                                     cosm1-series)))
-        (checking "series is accurate" 100 [d (sg/reasonable-double {:min (- (/ Math/PI 4))
-                                                                     :max (/ Math/PI 4)
-                                                                     :excluded-lower 0
-                                                                     :excluded-upper 0})]
-                  (is (near (- (Math/cos d) 1) (horner-eval cosm1-series (g/square d)))))))))
+    (let [terms (->> (g/- s/cos-series 1)
+                     (remove g/zero?)  ;; eliminate the useless zero coefficients of the odd powers of x
+                     (map double)      ;; we don't want the rational arithmetic to survive
+                     (take 8)          ;; the filtered series now has coefficients for x^2, x^4 ... x^16
+                     (cons 0.)         ;; cons 0 and reverse facilitate evaluation with Horner's method
+                     (reverse))
+          near (v/within 1e-10)
+          horner-eval (fn [x] (reduce (fn [a b] (+ (* a x) b)) terms))]
+      (is (= ci/cos-1-square-terms terms))
+      (checking "series is accurate" 100 [d (sg/reasonable-double {:min (- (/ Math/PI 4))
+                                                                   :max (/ Math/PI 4)
+                                                                   :excluded-lower 0
+                                                                   :excluded-upper 0})]
+                (is (near (- (Math/cos d) 1) (horner-eval (g/square d))))))))

--- a/test/emmy/series_test.cljc
+++ b/test/emmy/series_test.cljc
@@ -668,7 +668,7 @@
                      (reverse))
           near (v/within 1e-10)
           horner-eval (fn [x] (reduce (fn [a b] (+ (* a x) b)) terms))]
-      (is (= ci/cos-1-square-terms terms))
+      (is (every? #(near % 0) (map g/- ci/cos-1-square-terms terms)))
       (checking "series is accurate" 100 [d (sg/reasonable-double {:min (- (/ Math/PI 4))
                                                                    :max (/ Math/PI 4)
                                                                    :excluded-lower 0

--- a/test/emmy/simplify/rules_test.cljc
+++ b/test/emmy/simplify/rules_test.cljc
@@ -250,7 +250,7 @@
   (is (= (template
           (+ x (/ (- (log (+ 1 (* ~c/I z)))
                      (log (- 1 (* ~c/I z))))
-                  ~(c/complex 0.0 2.0))))
+                  ~(c/complex 0 2))))
          (r/specfun->logexp '(+ x (atan z))))
       "lame test... but this is meant to show that complex numbers appear in the
       replacement."))
@@ -368,11 +368,11 @@
 
 (deftest complex-test
   (testing "complex-exp"
-    (is (= `(~'+ (~'cos 1.0) (~'* ~c/I (~'sin 1.0)))
+    (is (= `(~'+ (~'cos 1) (~'* ~c/I (~'sin 1)))
            (r/exp->sincos `(~'exp ~(c/complex 0 1)))))
-    (is (= `(~'* (~'exp 1.0) (~'+ (~'cos 1.0) (~'* ~c/I (~'sin 1.0))))
+    (is (= `(~'* (~'exp 1) (~'+ (~'cos 1) (~'* ~c/I (~'sin 1))))
            (r/exp->sincos `(~'exp ~(c/complex 1 1)))))
-    (is (= `(~'expt (~'exp (~'* ~c/I ~'z)) 2.0)
+    (is (= `(~'expt (~'exp (~'* ~c/I ~'z)) 2)
            (r/exp-expand `(~'exp (~'* ~(c/complex 0 2) ~'z)))))
     (is (= '(expt (exp (* k t)) 2)
            (r/exp-expand '(exp (* 2 k t))))))

--- a/test/emmy/structure_test.cljc
+++ b/test/emmy/structure_test.cljc
@@ -6,7 +6,6 @@
             [clojure.test.check.generators :as gen]
             [com.gfredericks.test.chuck.clojure-test :refer [checking]]
             [emmy.abstract.number]
-            [emmy.complex :as c]
             [emmy.expression :as x]
             [emmy.function :as f]
             [emmy.generators :as sg]

--- a/test/emmy/structure_test.cljc
+++ b/test/emmy/structure_test.cljc
@@ -1248,8 +1248,8 @@
     (is (ish? (g/abs [3 4 5]) (g/sqrt 50)))
 
     (let [m (g/magnitude [#emmy/complex "3+4i" (g/sqrt 11)])]
-      (is (= (g/sqrt (g/square m))
-             (c/complex (g/abs m))))))
+      (is (v/= (g/sqrt (g/square m))
+               (g/abs m)))))
 
   (testing "g/real-part, g/imag-part, g/make-rectangular, g/make-polar"
     (let [s3      [3 (s/up 3) (s/down 3)]


### PR DESCRIPTION
- #151

  - By porting `complex.js` to Clojure, we can remove the dependency on
    this library on the JavaScript side as well as the Apache Commons
    complex implementation on the JVM side.

    The JavaScript implementation is followed fairly closely and done with
    generic Emmy arithmetic at the component level (except when that is
    clearly unnecessary). The `(complex)` constructor has been made
    equivalent to the reader parser.

    The former implementation made a special case of i^r, raising the
    complex unit to a real power, but it only worked for integral r, and
    threw an exception in other cases; this special case is removed.