### PR TITLE
Replace bigfraction.js with CLJS code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,9 +18,9 @@
     which may lose exactness because of the unwanted floating-point
     conversion. For this reason, when we emit a ratio in string form,
     we quote the arguments: `#emmy/ratio "1/2"` to prevent the conversion.
-    Consider this a deprecation notice for the unquoted form. Another,
-    unambiguous possibility would be to imitate the Complex reader syntax which
-    allows a vector pair e.g. `#emmy/ratio [1 2]`.
+    Consider this a deprecation notice for the unquoted form. We alsw
+    now allow the form `#emmy/ratio [1 2]`, like Complex, and now no
+    longer allow an initial `+` on the numerator.
 
 - #154:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## [unreleased]
 
-- #XXX
+- #155
 
   - Replace the implementation of arbitrary-precision rational arithmetic
     provided by `fraction.js` with Clojure code, allowing us to remove
@@ -18,7 +18,7 @@
     which may lose exactness because of the unwanted floating-point
     conversion. For this reason, when we emit a ratio in string form,
     we quote the arguments: `#emmy/ratio "1/2"` to prevent the conversion.
-    Consider this a deprecation notice for the unquoted form. We alsw
+    Consider this a deprecation notice for the unquoted form. We also
     now allow the form `#emmy/ratio [1 2]`, like Complex, and now no
     longer allow an initial `+` on the numerator.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,26 @@
 
 ## [unreleased]
 
+- #XXX
+
+  - Replace the implementation of arbitrary-precision rational arithmetic
+    provided by `fraction.js` with Clojure code, allowing us to remove
+    a JavaScript dependency.
+
+  - We note here a subtlety with fraction reader syntax. When the CLJS
+    compiler runs and encounters input like  `#emmy/ratio 1/2`, since
+    the compilation occurs in a JVM Clojure environment the 1/2 will
+    deserialize as a Ratio, which is then transformed by the reader into
+    code which will generate a ClojureScript `Fraction`. The ClojureScript
+    reader, however, evaluates the input as q JS expression resulting
+    in 0.5, which is then rationalized with an expensive algorithm
+    which may lose exactness because of the unwanted floating-point
+    conversion. For this reason, when we emit a ratio in string form,
+    we quote the arguments: `#emmy/ratio "1/2"` to prevent the conversion.
+    Consider this a deprecation notice for the unquoted form. Another,
+    unambiguous possibility would be to imitate the Complex reader syntax which
+    allows a vector pair e.g. `#emmy/ratio [1 2]`.
+
 - #154:
 
   - Adds `emmy.tape` with an implementation of reverse-mode automatic

--- a/src/emmy/bigfraction.cljs
+++ b/src/emmy/bigfraction.cljs
@@ -115,10 +115,13 @@
   (if (< a 0) (* -ONE a) a))
 
 (defn integer->
+  "Create a fraction with unit denominator."
   [n]
   (->Fraction (js/BigInt n) ONE))
 
 (defn ->real
+  "Coerce a fraction to real by performing the division
+   in the floating point domain"
   [^Fraction q]
   (/ (js/Number (.-n q)) (js/Number (.-d q))))
 
@@ -129,9 +132,9 @@
   (when (== ZERO b)
     (division-by-zero))
   (let [an (< a 0)
-        a (if an (* -ONE a) a)
+        a (bigint-abs a)
         bn (< b 0)
-        b (if bn (* -ONE b) b)
+        b (bigint-abs b)
         g (bigint-gcd a b)
         neg (not= an bn)
         abs_c (/ a g)

--- a/src/emmy/bigfraction.cljs
+++ b/src/emmy/bigfraction.cljs
@@ -1,751 +1,316 @@
-(ns bigfraction)
-
-(def C-ONE (js/BigInt 1))
-(def C-ZERO (js/BigInt 0))
-(def C-TEN (js/BigInt 10))
-(def C-TWO (js/BigInt 2))
-(def C-FIVE (js/BigInt 5))
-
-(deftype Fraction [s n d])
-
-(defn parse [p1 p2])
-  ;; const parse = function(p1, p2) {
-
-  ;;   let n = C_ZERO, d = C_ONE, s = C_ONE;
-
-  ;;   if (p1 === undefined || p1 === null) {
-  ;;     /* void */
-  ;;   } else if (p2 !== undefined) {
-  ;;     n = BigInt(p1);
-  ;;     d = BigInt(p2);
-  ;;     s = n * d;
-
-  ;;     if (n % C_ONE !== C_ZERO || d % C_ONE !== C_ZERO) {
-  ;;       throw NonIntegerParameter();
-  ;;     }
-
-  ;;   } else if (typeof p1 === "object") {
-  ;;     if ("d" in p1 && "n" in p1) {
-  ;;       n = BigInt(p1["n"]);
-  ;;       d = BigInt(p1["d"]);
-  ;;       if ("s" in p1)
-  ;;         n*= BigInt(p1["s"]);
-  ;;     } else if (0 in p1) {
-  ;;       n = BigInt(p1[0]);
-  ;;       if (1 in p1)
-  ;;         d = BigInt(p1[1]);
-  ;;     } else if (p1 instanceof BigInt) {
-  ;;       n = BigInt(p1);
-  ;;     } else {
-  ;;       throw InvalidParameter();
-  ;;     }
-  ;;     s = n * d;
-  ;;   } else if (typeof p1 === "bigint") {
-  ;;     n = p1;
-  ;;     s = p1;
-  ;;     d = C_ONE;
-  ;;   } else if (typeof p1 === "number") {
-
-  ;;     if (isNaN(p1)) {
-  ;;       throw InvalidParameter();
-  ;;     }
-
-  ;;     if (p1 < 0) {
-  ;;       s = -C_ONE;
-  ;;       p1 = -p1;
-  ;;     }
-
-  ;;     if (p1 % 1 === 0) {
-  ;;       n = BigInt(p1);
-  ;;     } else if (p1 > 0) { // check for != 0, scale would become NaN (log(0)), which converges really slow
-
-  ;;       let z = 1;
-
-  ;;       let A = 0, B = 1;
-  ;;       let C = 1, D = 1;
-
-  ;;       let N = 10000000;
-
-  ;;       if (p1 >= 1) {
-  ;;         z = 10 ** Math.floor(1 + Math.log10(p1));
-  ;;         p1/= z;
-  ;;       }
-
-  ;;       // Using Farey Sequences
-
-  ;;       while (B <= N && D <= N) {
-  ;;         let M = (A + C) / (B + D);
-
-  ;;         if (p1 === M) {
-  ;;           if (B + D <= N) {
-  ;;             n = A + C;
-  ;;             d = B + D;
-  ;;           } else if (D > B) {
-  ;;             n = C;
-  ;;             d = D;
-  ;;           } else {
-  ;;             n = A;
-  ;;             d = B;
-  ;;           }
-  ;;           break;
-
-  ;;         } else {
-
-  ;;           if (p1 > M) {
-  ;;             A+= C;
-  ;;             B+= D;
-  ;;           } else {
-  ;;             C+= A;
-  ;;             D+= B;
-  ;;           }
-
-  ;;           if (B > N) {
-  ;;             n = C;
-  ;;             d = D;
-  ;;           } else {
-  ;;             n = A;
-  ;;             d = B;
-  ;;           }
-  ;;         }
-  ;;       }
-  ;;       n = BigInt(n) * BigInt(z);
-  ;;       d = BigInt(d);
-
-  ;;     }
-
-  ;;   } else if (typeof p1 === "string") {
-
-  ;;     let ndx = 0;
-
-  ;;     let v = C_ZERO, w = C_ZERO, x = C_ZERO, y = C_ONE, z = C_ONE;
-
-  ;;     let match = p1.match(/\d+|./g);
-
-  ;;     if (match === null)
-  ;;       throw InvalidParameter();
-
-  ;;     if (match[ndx] === '-') {// Check for minus sign at the beginning
-  ;;       s = -C_ONE;
-  ;;       ndx++;
-  ;;     } else if (match[ndx] === '+') {// Check for plus sign at the beginning
-  ;;       ndx++;
-  ;;     }
-
-  ;;     if (match.length === ndx + 1) { // Check if it's just a simple number "1234"
-  ;;       w = assign(match[ndx++], s);
-  ;;     } else if (match[ndx + 1] === '.' || match[ndx] === '.') { // Check if it's a decimal number
-
-  ;;       if (match[ndx] !== '.') { // Handle 0.5 and .5
-  ;;         v = assign(match[ndx++], s);
-  ;;       }
-  ;;       ndx++;
-
-  ;;       // Check for decimal places
-  ;;       if (ndx + 1 === match.length || match[ndx + 1] === '(' && match[ndx + 3] === ')' || match[ndx + 1] === "'" && match[ndx + 3] === "'") {
-  ;;         w = assign(match[ndx], s);
-  ;;         y = C_TEN ** BigInt(match[ndx].length);
-  ;;         ndx++;
-  ;;       }
-
-  ;;       // Check for repeating places
-  ;;       if (match[ndx] === '(' && match[ndx + 2] === ')' || match[ndx] === "'" && match[ndx + 2] === "'") {
-  ;;         x = assign(match[ndx + 1], s);
-  ;;         z = C_TEN ** BigInt(match[ndx + 1].length) - C_ONE;
-  ;;         ndx+= 3;
-  ;;       }
-
-  ;;     } else if (match[ndx + 1] === '/' || match[ndx + 1] === ':') { // Check for a simple fraction "123/456" or "123:456"
-  ;;       w = assign(match[ndx], s);
-  ;;       y = assign(match[ndx + 2], C_ONE);
-  ;;       ndx+= 3;
-  ;;     } else if (match[ndx + 3] === '/' && match[ndx + 1] === ' ') { // Check for a complex fraction "123 1/2"
-  ;;       v = assign(match[ndx], s);
-  ;;       w = assign(match[ndx + 2], s);
-  ;;       y = assign(match[ndx + 4], C_ONE);
-  ;;       ndx+= 5;
-  ;;     }
-
-  ;;     if (match.length <= ndx) { // Check for more tokens on the stack
-  ;;       d = y * z;
-  ;;       s = /* void */
-  ;;       n = x + d * v + z * w;
-  ;;     } else {
-  ;;       throw InvalidParameter();
-  ;;     }
-
-  ;;   } else {
-  ;;     throw InvalidParameter();
-  ;;   }
-
-  ;;   if (d === C_ZERO) {
-  ;;     throw DivisionByZero();
-  ;;   }
-
-  ;;   P["s"] = s < C_ZERO ? -C_ONE : C_ONE;
-  ;;   P["n"] = n < C_ZERO ? -n : n;
-  ;;   P["d"] = d < C_ZERO ? -d : d;
-  ;; };
-
-(defn gcd [a b])
-;; function gcd(a, b) {
-
-;;                     if (!a)
-;;                     return b;
-;;                     if (!b)
-;;                     return a;
-
-;;                     while (1) {
-;;                                a%= b;
-;;                                if (!a)
-;;                                return b;
-;;                                b%= a;
-;;                                if (!b)
-;;                                return a;
-;;                                }
-;;                     }
-
-(defn new-fraction [])
-;; // Creates a new Fraction internally without the need of the bulky constructor
-;; function newFraction(n, d) {
-
-;;                             if (d === C_ZERO) {
-;;                                                throw DivisionByZero();
-;;                                                }
-
-;;                             const f = Object.create(Fraction.prototype);
-;;                             f["s"] = n < C_ZERO ? -C_ONE : C_ONE;
-
-;;                             n = n < C_ZERO ? -n : n;
-
-;;                             const a = gcd(n, d);
-
-;;                             f["n"] = n / a;
-;;                             f["d"] = d / a;
-;;                             return f;
-;;                             }
-
-(defn build [])
-;; function Fraction(a, b) {
-
-;;                          parse(a, b);
-
-;;                          if (this instanceof Fraction) {
-;;                                                         a = gcd(P["d"], P["n"]); // Abuse a
-;;                                                         this["s"] = P["s"];
-;;                                                         this["n"] = P["n"] / a;
-;;                                                         this["d"] = P["d"] / a;
-;;                                                         } else {
-;;                                                                 return newFraction(P['s'] * P['n'], P['d']);
-;;                                                                 }
-;;                          }
-
-
-(defn abs [x])
-;; /**
-;;      * Calculates the absolute value
-;;      *
-;;      * Ex: new Fraction(-4).abs() => 4
-;;      **/
-;;     "abs": function() {
-
-;;       return newFraction(this["n"], this["d"]);
-;;     },
-
-(defn neg [^Fraction x]
-  )
-;;     /**
-;;      * Inverts the sign of the current fraction
-;;      *
-;;      * Ex: new Fraction(-4).neg() => 4
-;;      **/
-;;     "neg": function() {
-
-;;       return newFraction(-this["s"] * this["n"], this["d"]);
-;;     },
-
-(defn add [^Fraction a ^Fraction b]
-  (Fraction. (* (.-s a))))
-;;     /**
-;;      * Adds two rational numbers
-;;      *
-;;      * Ex: new Fraction({n: 2, d: 3}).add("14.9") => 467 / 30
-;;      **/
-;;     "add": function(a, b) {
-
-;;       parse(a, b);
-;;       return newFraction(
-;;         this["s"] * this["n"] * P["d"] + P["s"] * this["d"] * P["n"],
-;;         this["d"] * P["d"]
-;;       );
-;;     },
-
-(defn sub [a b])
-;;     /**
-;;      * Subtracts two rational numbers
-;;      *
-;;      * Ex: new Fraction({n: 2, d: 3}).add("14.9") => -427 / 30
-;;      **/
-;;     "sub": function(a, b) {
-
-;;       parse(a, b);
-;;       return newFraction(
-;;         this["s"] * this["n"] * P["d"] - P["s"] * this["d"] * P["n"],
-;;         this["d"] * P["d"]
-;;       );
-;;     },
-
-(defn mul [a b])
-;;     /**
-;;      * Multiplies two rational numbers
-;;      *
-;;      * Ex: new Fraction("-17.(345)").mul(3) => 5776 / 111
-;;      **/
-;;     "mul": function(a, b) {
-
-;;       parse(a, b);
-;;       return newFraction(
-;;         this["s"] * P["s"] * this["n"] * P["n"],
-;;         this["d"] * P["d"]
-;;       );
-;;     },
-
-(defn div [a b])
-;;     /**
-;;      * Divides two rational numbers
-;;      *
-;;      * Ex: new Fraction("-17.(345)").inverse().div(3)
-;;      **/
-;;     "div": function(a, b) {
-
-;;       parse(a, b);
-;;       return newFraction(
-;;         this["s"] * P["s"] * this["n"] * P["d"],
-;;         this["d"] * P["n"]
-;;       );
-;;     },
-
-(defn clone [x])
-;;     /**
-;;      * Clones the actual object
-;;      *
-;;      * Ex: new Fraction("-17.(345)").clone()
-;;      **/
-;;     "clone": function() {
-;;       return newFraction(this['s'] * this['n'], this['d']);
-;;     },
-
-(defn mod [x])
-;;     /**
-;;      * Calculates the modulo of two rational numbers - a more precise fmod
-;;      *
-;;      * Ex: new Fraction('4.(3)').mod([7, 8]) => (13/3) % (7/8) = (5/6)
-;;      **/
-;;     "mod": function(a, b) {
-
-;;       if (a === undefined) {
-;;         return newFraction(this["s"] * this["n"] % this["d"], C_ONE);
-;;       }
-
-;;       parse(a, b);
-;;       if (0 === P["n"] && 0 === this["d"]) {
-;;         throw DivisionByZero();
-;;       }
-
-;;       /*
-;;        * First silly attempt, kinda slow
-;;        *
-;;        return that["sub"]({
-;;        "n": num["n"] * Math.floor((this.n / this.d) / (num.n / num.d)),
-;;        "d": num["d"],
-;;        "s": this["s"]
-;;        });*/
-
-;;       /*
-;;        * New attempt: a1 / b1 = a2 / b2 * q + r
-;;        * => b2 * a1 = a2 * b1 * q + b1 * b2 * r
-;;        * => (b2 * a1 % a2 * b1) / (b1 * b2)
-;;        */
-;;       return newFraction(
-;;         this["s"] * (P["d"] * this["n"]) % (P["n"] * this["d"]),
-;;         P["d"] * this["d"]
-;;       );
-;;     },
-
-(defn gcd [x])
-;;     /**
-;;      * Calculates the fractional gcd of two rational numbers
-;;      *
-;;      * Ex: new Fraction(5,8).gcd(3,7) => 1/56
-;;      */
-;;     "gcd": function(a, b) {
-
-;;       parse(a, b);
-
-;;       // gcd(a / b, c / d) = gcd(a, c) / lcm(b, d)
-
-;;       return newFraction(gcd(P["n"], this["n"]) * gcd(P["d"], this["d"]), P["d"] * this["d"]);
-;;     },
-
-(defn lcm [x])
-;;     /**
-;;      * Calculates the fractional lcm of two rational numbers
-;;      *
-;;      * Ex: new Fraction(5,8).lcm(3,7) => 15
-;;      */
-;;     "lcm": function(a, b) {
-
-;;       parse(a, b);
-
-;;       // lcm(a / b, c / d) = lcm(a, c) / gcd(b, d)
-
-;;       if (P["n"] === C_ZERO && this["n"] === C_ZERO) {
-;;         return newFraction(C_ZERO, C_ONE);
-;;       }
-;;       return newFraction(P["n"] * this["n"], gcd(P["n"], this["n"]) * gcd(P["d"], this["d"]));
-;;     },
-
-(defn inverse [x])
-;;     /**
-;;      * Gets the inverse of the fraction, means numerator and denominator are exchanged
-;;      *
-;;      * Ex: new Fraction([-3, 4]).inverse() => -4 / 3
-;;      **/
-;;     "inverse": function() {
-;;       return newFraction(this["s"] * this["d"], this["n"]);
-;;     },
-
-(defn pow [a b])
-;;     /**
-;;      * Calculates the fraction to some integer exponent
-;;      *
-;;      * Ex: new Fraction(-1,2).pow(-3) => -8
-;;      */
-;;     "pow": function(a, b) {
-
-;;       parse(a, b);
-
-;;       // Trivial case when exp is an integer
-
-;;       if (P['d'] === C_ONE) {
-
-;;         if (P['s'] < C_ZERO) {
-;;           return newFraction((this['s'] * this["d"]) ** P['n'], this["n"] ** P['n']);
-;;         } else {
-;;           return newFraction((this['s'] * this["n"]) ** P['n'], this["d"] ** P['n']);
-;;         }
-;;       }
-
-;;       // Negative roots become complex
-;;       //     (-a/b)^(c/d) = x
-;;       // <=> (-1)^(c/d) * (a/b)^(c/d) = x
-;;       // <=> (cos(pi) + i*sin(pi))^(c/d) * (a/b)^(c/d) = x
-;;       // <=> (cos(c*pi/d) + i*sin(c*pi/d)) * (a/b)^(c/d) = x       # DeMoivre's formula
-;;       // From which follows that only for c=0 the root is non-complex
-;;       if (this['s'] < C_ZERO) return null;
-
-;;       // Now prime factor n and d
-;;       let N = factorize(this['n']);
-;;       let D = factorize(this['d']);
-
-;;       // Exponentiate and take root for n and d individually
-;;       let n = C_ONE;
-;;       let d = C_ONE;
-;;       for (let k in N) {
-;;         if (k === '1') continue;
-;;         if (k === '0') {
-;;           n = C_ZERO;
-;;           break;
-;;         }
-;;         N[k]*= P['n'];
-
-;;         if (N[k] % P['d'] === C_ZERO) {
-;;           N[k]/= P['d'];
-;;         } else return null;
-;;         n*= BigInt(k) ** N[k];
-;;       }
-
-;;       for (let k in D) {
-;;         if (k === '1') continue;
-;;         D[k]*= P['n'];
-
-;;         if (D[k] % P['d'] === C_ZERO) {
-;;           D[k]/= P['d'];
-;;         } else return null;
-;;         d*= BigInt(k) ** D[k];
-;;       }
-
-;;       if (P['s'] < C_ZERO) {
-;;         return newFraction(d, n);
-;;       }
-;;       return newFraction(n, d);
-;;     },
-
-(defn equals [a b])
-;;     /**
-;;      * Check if two rational numbers are the same
-;;      *
-;;      * Ex: new Fraction(19.6).equals([98, 5]);
-;;      **/
-;;     "equals": function(a, b) {
-
-;;       parse(a, b);
-;;       return this["s"] * this["n"] * P["d"] === P["s"] * P["n"] * this["d"]; // Same as compare() === 0
-;;     },
-
-(defn compare [a b])
-;;     /**
-;;      * Check if two rational numbers are the same
-;;      *
-;;      * Ex: new Fraction(19.6).equals([98, 5]);
-;;      **/
-;;     "compare": function(a, b) {
-
-;;       parse(a, b);
-;;       let t = (this["s"] * this["n"] * P["d"] - P["s"] * P["n"] * this["d"]);
-
-;;       return (C_ZERO < t) - (t < C_ZERO);
-;;     },
-
-(defn ceil [x])
-;;     /**
-;;      * Calculates the ceil of a rational number
-;;      *
-;;      * Ex: new Fraction('4.(3)').ceil() => (5 / 1)
-;;      **/
-;;     "ceil": function(places) {
-
-;;       places = C_TEN ** BigInt(places || 0);
-
-;;       return newFraction(this["s"] * places * this["n"] / this["d"] +
-;;         (places * this["n"] % this["d"] > C_ZERO && this["s"] >= C_ZERO ? C_ONE : C_ZERO),
-;;         places);
-;;     },
-
-(defn floor [x])
-;;     /**
-;;      * Calculates the floor of a rational number
-;;      *
-;;      * Ex: new Fraction('4.(3)').floor() => (4 / 1)
-;;      **/
-;;     "floor": function(places) {
-
-;;       places = C_TEN ** BigInt(places || 0);
-
-;;       return newFraction(this["s"] * places * this["n"] / this["d"] -
-;;         (places * this["n"] % this["d"] > C_ZERO && this["s"] < C_ZERO ? C_ONE : C_ZERO),
-;;         places);
-;;     },
-
-(defn round [x])
-;;     /**
-;;      * Rounds a rational numbers
-;;      *
-;;      * Ex: new Fraction('4.(3)').round() => (4 / 1)
-;;      **/
-;;     "round": function(places) {
-
-;;       places = C_TEN ** BigInt(places || 0);
-
-;;       /* Derivation:
-
-;;       s >= 0:
-;;         round(n / d) = trunc(n / d) + (n % d) / d >= 0.5 ? 1 : 0
-;;                      = trunc(n / d) + 2(n % d) >= d ? 1 : 0
-;;       s < 0:
-;;         round(n / d) =-trunc(n / d) - (n % d) / d > 0.5 ? 1 : 0
-;;                      =-trunc(n / d) - 2(n % d) > d ? 1 : 0
-
-;;       =>:
-
-;;       round(s * n / d) = s * trunc(n / d) + s * (C + 2(n % d) > d ? 1 : 0)
-;;           where C = s >= 0 ? 1 : 0, to fix the >= for the positve case.
-;;       */
-
-;;       return newFraction(this["s"] * places * this["n"] / this["d"] +
-;;         this["s"] * ((this["s"] >= C_ZERO ? C_ONE : C_ZERO) + C_TWO * (places * this["n"] % this["d"]) > this["d"] ? C_ONE : C_ZERO),
-;;         places);
-;;     },
-
-(defn divisible [a b])
-;;     /**
-;;      * Check if two rational numbers are divisible
-;;      *
-;;      * Ex: new Fraction(19.6).divisible(1.5);
-;;      */
-;;     "divisible": function(a, b) {
-
-;;       parse(a, b);
-;;       return !(!(P["n"] * this["d"]) || ((this["n"] * P["d"]) % (P["n"] * this["d"])));
-;;     },
-
-(defn value-of [x])
-;;     /**
-;;      * Returns a decimal representation of the fraction
-;;      *
-;;      * Ex: new Fraction("100.'91823'").valueOf() => 100.91823918239183
-;;      **/
-;;     'valueOf': function() {
-;;       // Best we can do so far
-;;       return Number(this["s"] * this["n"]) / Number(this["d"]);
-;;     },
-
-
-(defn to-string [x])
-;; /**
-;;      * Creates a string representation of a fraction with all digits
-;;      *
-;;      * Ex: new Fraction("100.'91823'").toString() => "100.(91823)"
-;;      **/
-;;     'toString': function(dec) {
-
-;;       let N = this["n"];
-;;       let D = this["d"];
-
-;;       function trunc(x) {
-;;           return typeof x === 'bigint' ? x : Math.floor(x);
-;;       }
-
-;;       dec = dec || 15; // 15 = decimal places when no repetition
-
-;;       let cycLen = cycleLen(N, D); // Cycle length
-;;       let cycOff = cycleStart(N, D, cycLen); // Cycle start
-
-;;       let str = this['s'] < C_ZERO ? "-" : "";
-
-;;       // Append integer part
-;;       str+= trunc(N / D);
-
-;;       N%= D;
-;;       N*= C_TEN;
-
-;;       if (N)
-;;         str+= ".";
-
-;;       if (cycLen) {
-
-;;         for (let i = cycOff; i--;) {
-;;           str+= trunc(N / D);
-;;           N%= D;
-;;           N*= C_TEN;
-;;         }
-;;         str+= "(";
-;;         for (let i = cycLen; i--;) {
-;;           str+= trunc(N / D);
-;;           N%= D;
-;;           N*= C_TEN;
-;;         }
-;;         str+= ")";
-;;       } else {
-;;         for (let i = dec; N && i--;) {
-;;           str+= trunc(N / D);
-;;           N%= D;
-;;           N*= C_TEN;
-;;         }
-;;       }
-;;       return str;
-;;     },
-
-(defn to-fraction [x])
-;;     /**
-;;      * Returns a string-fraction representation of a Fraction object
-;;      *
-;;      * Ex: new Fraction("1.'3'").toFraction() => "4 1/3"
-;;      **/
-;;     'toFraction': function(excludeWhole) {
-
-;;       let n = this["n"];
-;;       let d = this["d"];
-;;       let str = this['s'] < C_ZERO ? "-" : "";
-
-;;       if (d === C_ONE) {
-;;         str+= n;
-;;       } else {
-;;         let whole = n / d;
-;;         if (excludeWhole && whole > C_ZERO) {
-;;           str+= whole;
-;;           str+= " ";
-;;           n%= d;
-;;         }
-
-;;         str+= n;
-;;         str+= '/';
-;;         str+= d;
-;;       }
-;;       return str;
-;;     },
-
-(defn to-latex [])
-;;     /**
-;;      * Returns a latex representation of a Fraction object
-;;      *
-;;      * Ex: new Fraction("1.'3'").toLatex() => "\frac{4}{3}"
-;;      **/
-;;     'toLatex': function(excludeWhole) {
-
-;;       let n = this["n"];
-;;       let d = this["d"];
-;;       let str = this['s'] < C_ZERO ? "-" : "";
-
-;;       if (d === C_ONE) {
-;;         str+= n;
-;;       } else {
-;;         let whole = n / d;
-;;         if (excludeWhole && whole > C_ZERO) {
-;;           str+= whole;
-;;           n%= d;
-;;         }
-
-;;         str+= "\\frac{";
-;;         str+= n;
-;;         str+= '}{';
-;;         str+= d;
-;;         str+= '}';
-;;       }
-;;       return str;
-;;     },
-
-(defn to-continued [])
-;;     /**
-;;      * Returns an array of continued fraction elements
-;;      *
-;;      * Ex: new Fraction("7/8").toContinued() => [0,1,7]
-;;      */
-;;     'toContinued': function() {
-
-;;       let a = this['n'];
-;;       let b = this['d'];
-;;       let res = [];
-
-;;       do {
-;;         res.push(a / b);
-;;         let t = a % b;
-;;         a = b;
-;;         b = t;
-;;       } while (a !== C_ONE);
-
-;;       return res;
-;;     },
-
-(defn simplify [])
-
-;;     "simplify": function(eps) {
-
-;;       eps = eps || 0.001;
-
-;;       const thisABS = this['abs']();
-;;       const cont = thisABS['toContinued']();
-
-;;       for (let i = 1; i < cont.length; i++) {
-
-;;         let s = newFraction(cont[i - 1], C_ONE);
-;;         for (let k = i - 2; k >= 0; k--) {
-;;           s = s['inverse']()['add'](cont[k]);
-;;         }
-
-;;         if (Math.abs(s['sub'](thisABS).valueOf()) < eps) {
-;;           return s['mul'](this['s']);
-;;         }
-;;       }
-;;       return this;
-;;     }
-;;   };
+#_"SPDX-License-Identifier: GPL-3.0"
+
+(ns emmy.bigfraction
+  "A CLJS bigfraction is a coprime pair of JavaScript BigInts, with the
+   sign carried in the numerator."
+  (:refer-clojure :exclude [abs zero? neg?])
+  (:require
+   [clojure.core :as core]
+   [emmy.value :as v]
+   [goog.array :as garray]))
+
+(def ^:private ZERO (js/BigInt 0))
+(def ^:private ONE (js/BigInt 1))
+(def ^:private TEN (js/BigInt 10))
+(def ^:private -ONE (- ONE))
+
+(defn- bigint?
+  "Returns true if x is a BigInt. There is a similar function in [[emmy.util]],
+   but we prefer that this library avoid that dependency."
+  [x]
+  (= "bigint" (goog/typeOf x)))
+
+(declare eq cmp ->real)
+
+(deftype Fraction [^js/BigInt n ^js/BigInt d]
+
+  Object
+  (valueOf [this] (->real this))
+  (toString [_] (str n "/" d))
+
+  ;; these are the remaining dependencies on value.
+  ;; Maybe they should be part of extend-type in the ratio library.
+  v/IKind
+  (kind [_] :emmy.ratio/ratio)
+
+  v/INumericTower
+
+  v/IReal
+
+  v/Numerical
+  (numerical? [_] true)
+
+  IHash
+  (-hash [x]
+    (bit-xor
+     (-hash (.-n x))
+     (-hash (.-d x))))
+
+  IComparable
+  (-compare [this other]
+    (cond (instance? Fraction other)
+          (cmp this other)
+
+          (bigint? other)
+          (compare n (* d other))
+
+          :else
+          (let [o-value (.valueOf other)]
+            (if (v/real? o-value)
+              (garray/defaultCompare this o-value)
+              (throw (js/Error (str "Cannot compare " this " to " o-value " : " (v/kind o-value) " (" (type o-value) ")")))))))
+
+  IEquiv
+  (-equiv [this other]
+    (cond (instance? Fraction other) (eq this other)
+          (v/integral? other) (and (== ONE d) (v/= n other))
+          :else false))
+
+  IPrintWithWriter
+  (-pr-writer [_ writer _] (write-all writer "#emmy/ratio \"" n "/" d "\"")))
+
+(def ^:private F_ONE (Fraction. ONE ONE))
+
+(defn division-by-zero
+  "Throws JS exception used to signal an attempt to construct a fraction
+   with zero denominator."
+  []
+  (throw (js/Error "Fraction with zero denominator")))
+
+(defn numerator [^Fraction x]
+  (.-n x))
+
+(defn denominator [^Fraction x]
+  (.-d x))
+
+(defn zero?
+  "Returns true iff `x` is a zero fraction."
+  [^Fraction x]
+  (let [a (.-n x)]
+    (== ZERO a)))
+
+(defn one?
+  "Returns true iff `x` is a unit fraction."
+  [^Fraction x]
+  (let [a (.-n x)
+        b (.-d x)]
+    (== a b)))
+
+(defn eq [^Fraction x ^Fraction y]
+  (let [a (.-n x)
+        b (.-d x)
+        c (.-n y)
+        d (.-d y)]
+    (and (== a c) (== b d))))
+
+(defn bigint-gcd
+  "GCD assuming a and b are BigInts > 0"
+  [^js/BigInt a ^js/BigInt b]
+  (loop [a a
+         b b]
+    (if (== b ZERO) a
+        (recur b (core/mod a b)))))
+
+(defn- bigint-abs [a]
+  (if (< a 0) (* -ONE a) a))
+
+(defn integer->
+  [n]
+  (->Fraction (js/BigInt n) ONE))
+
+(defn ->real
+  [^Fraction q]
+  (/ (js/Number (.-n q)) (js/Number (.-d q))))
+
+(defn ->normal-form
+  "We assume we are given two BigInts, with b > 0. The GCD is divided out, and the
+   sign is carried in the numerator."
+  [^js/BigInt a ^js/BigInt b]
+  (when (== ZERO b)
+    (division-by-zero))
+  (let [an (< a 0)
+        a (if an (* -ONE a) a)
+        bn (< b 0)
+        b (if bn (* -ONE b) b)
+        g (bigint-gcd a b)
+        neg (not= an bn)
+        abs_c (/ a g)
+        c (if neg (* -ONE abs_c) abs_c)
+        d (/ b g)]
+    (->Fraction c d)))
+
+(defn make
+  "Produces a fraction in canonical form. Note that the canonical form of an integer is
+   an integer, so if `(one? b)` you just get a."
+  [a b]
+  (let [a (js/BigInt a)
+        b (js/BigInt b)]
+    (when (== 0 b)
+      (division-by-zero))
+    (->normal-form a b)))
+
+(defn- js-expt
+  "Use the `js*` escape clause to get access to the JavaScript `**` operator,
+   which can exponentiate two BigInts exactly."
+  [a b]
+  (js* "(~{} ** ~{})" a b))
+
+(def ^:private double-re #"(-?\d+)(\.(\d+))?([Ee]([+-]\d+))?")
+
+(defn real->
+  "Clojure converts the real to BigDecimal and rationalizes from that.
+   The JVM documentation explains that the BigDecimal value will correspond
+   to what would be printed for the double value. We attempt to do the
+   same thing here by converting to a string and converting from there."
+  [x]
+  (let [s (.toString x)]
+    (if-let [[_ int _ frac _ exp] (re-matches double-re s)]
+      (let [scale (- (js/parseInt (or exp "0"))
+                     (count (or frac "")))
+            scale-neg (< scale 0)
+            mantissa (js/BigInt (str int frac))
+            exponent (js/BigInt (js-expt TEN (js/BigInt (Math/abs scale))))]
+        (if scale-neg
+          (->normal-form mantissa exponent)
+          (Fraction. (* mantissa exponent) ONE)))
+      (throw (js/Error (str "Cannot convert " x " to ratio."))))))
+
+(defn abs
+  "Absolute value of the fraction `x`."
+  [^Fraction x]
+  (let [n (.-n x)
+        d (.-d x)]
+    (if (< n 0) (->Fraction (* -ONE n) d) x)))
+
+(defn neg
+  "Negation of the fraction `x`."
+  [^Fraction x]
+  (let [n (.-n x)
+        d (.-d x)]
+    (->Fraction (* -ONE n) d)))
+
+(defn neg?
+  "True if $x<0$."
+  [^Fraction x]
+  (< (.-n x) 0))
+
+(defn add
+  "Returns the sum of `x` and `y`."
+  [^Fraction x ^Fraction y]
+  (let [a (.-n x)
+        b (.-d x)
+        c (.-n y)
+        d (.-d y)]
+    (->normal-form (+ (* a d) (* b c)) (* b d))))
+
+(defn sub
+  "Returns the difference of `x` and `y`."
+  [^Fraction x ^Fraction y]
+  (let [a (.-n x)
+        b (.-d x)
+        c (.-n y)
+        d (.-d y)]
+    (->normal-form (core/- (core/* a d) (core/* b c)) (core/* b d))))
+
+(defn mul
+  "Returns the product of `x` and `y`."
+  [^Fraction x ^Fraction y]
+  (let [a (.-n x)
+        b (.-d x)
+        c (.-n y)
+        d (.-d y)]
+    (->normal-form (core/* a c) (core/* b d))))
+
+(defn div
+  "Returns the quotient of `x` and `y`."
+  [^Fraction x ^Fraction y]
+  (let [a (.-n x)
+        b (.-d x)
+        c (.-n y)
+        d (.-d y)]
+    (->normal-form (core/* a d) (core/* b c))))
+
+(defn invert
+  "Returns the reciprocal of `x`, but throws if $x=0$."
+  [^Fraction x]
+  (let [a (.-n x)
+        b (.-d x)
+        neg (< a 0)]
+    (when (== ZERO a)
+      (division-by-zero))
+    (if neg
+      (->Fraction (* -ONE b) (* -ONE a))
+      (->Fraction b a))))
+
+(defn cmp
+  "Compares the fractions `x` and `y`, returning -1, 0, or 1."
+  [^Fraction x ^Fraction y]
+  (let [a (.-n x)
+        b (.-d x)
+        c (.-n y)
+        d (.-d y)
+        s (- (* a d) (* b c))]
+    (cond (< s 0) -1
+          (> s 0) 1
+          :else 0)))
+
+(defn integer-power
+  "Raises the fraction `x` to the integer power `n`."
+  [^Fraction x n]
+  (let [a (.-n x)
+        b (.-d x)
+        N (js/BigInt n)]
+    (cond
+      (= n ZERO) F_ONE
+      (= n ONE) x
+      ;; We skip to-normal-form, since if the input fractions are in
+      ;; normal form, so will their exponentiation be.
+      (> N ZERO) (->normal-form (js-expt a N) (js-expt b N))
+      :else (->normal-form (js-expt b (- N)) (js-expt a (- N))))))
+
+(defn promote
+  "If the fraction has a unit denominator, return the numerator, else the fraction."
+  [^Fraction x]
+  (if (== ONE (.-d x)) (.-n x) x))
+
+(defn ceil
+  "Ceiling. Result is a BigInt."
+  [^Fraction x]
+  (let [a (.-n x)
+        b (.-d x)]
+    (+ (/ a b) (if (or (< a 0)
+                       (== (js-mod a b) ZERO))
+                 ZERO
+                 ONE))))
+
+(defn floor
+  "Floor. Result is a BigInt."
+  [^Fraction x]
+  (let [a (.-n x)
+        b (.-d x)]
+    (- (/ a b) (if (or (> a 0)
+                       (== (js-mod a b) ZERO))
+                 ZERO
+                 ONE))))
+
+(defn quotient
+  "Fractions form a field, so somewhat dubiously the function returns
+   the largest integer N for which $Ny\\le x$."
+  [x y]
+  (let [z (div x y)]
+    (if (neg? z)
+      (ceil z)
+      (floor z))))
+
+(defn remainder
+  "If $q$ is `(quotient x y)`, returns $x-qy$."
+  [x y]
+  (sub x (mul (Fraction. (quotient x y) ONE) y)))
+
+(defn gcd
+  [^Fraction x ^Fraction y]
+  (let [a (.-n x)
+        b (.-d x)
+        c (.-n y)
+        d (.-d y)]
+    (abs (->normal-form (* (bigint-gcd a c) (bigint-gcd b d)) (* b d)))))

--- a/src/emmy/bigfraction.cljs
+++ b/src/emmy/bigfraction.cljs
@@ -1,0 +1,751 @@
+(ns bigfraction)
+
+(def C-ONE (js/BigInt 1))
+(def C-ZERO (js/BigInt 0))
+(def C-TEN (js/BigInt 10))
+(def C-TWO (js/BigInt 2))
+(def C-FIVE (js/BigInt 5))
+
+(deftype Fraction [s n d])
+
+(defn parse [p1 p2])
+  ;; const parse = function(p1, p2) {
+
+  ;;   let n = C_ZERO, d = C_ONE, s = C_ONE;
+
+  ;;   if (p1 === undefined || p1 === null) {
+  ;;     /* void */
+  ;;   } else if (p2 !== undefined) {
+  ;;     n = BigInt(p1);
+  ;;     d = BigInt(p2);
+  ;;     s = n * d;
+
+  ;;     if (n % C_ONE !== C_ZERO || d % C_ONE !== C_ZERO) {
+  ;;       throw NonIntegerParameter();
+  ;;     }
+
+  ;;   } else if (typeof p1 === "object") {
+  ;;     if ("d" in p1 && "n" in p1) {
+  ;;       n = BigInt(p1["n"]);
+  ;;       d = BigInt(p1["d"]);
+  ;;       if ("s" in p1)
+  ;;         n*= BigInt(p1["s"]);
+  ;;     } else if (0 in p1) {
+  ;;       n = BigInt(p1[0]);
+  ;;       if (1 in p1)
+  ;;         d = BigInt(p1[1]);
+  ;;     } else if (p1 instanceof BigInt) {
+  ;;       n = BigInt(p1);
+  ;;     } else {
+  ;;       throw InvalidParameter();
+  ;;     }
+  ;;     s = n * d;
+  ;;   } else if (typeof p1 === "bigint") {
+  ;;     n = p1;
+  ;;     s = p1;
+  ;;     d = C_ONE;
+  ;;   } else if (typeof p1 === "number") {
+
+  ;;     if (isNaN(p1)) {
+  ;;       throw InvalidParameter();
+  ;;     }
+
+  ;;     if (p1 < 0) {
+  ;;       s = -C_ONE;
+  ;;       p1 = -p1;
+  ;;     }
+
+  ;;     if (p1 % 1 === 0) {
+  ;;       n = BigInt(p1);
+  ;;     } else if (p1 > 0) { // check for != 0, scale would become NaN (log(0)), which converges really slow
+
+  ;;       let z = 1;
+
+  ;;       let A = 0, B = 1;
+  ;;       let C = 1, D = 1;
+
+  ;;       let N = 10000000;
+
+  ;;       if (p1 >= 1) {
+  ;;         z = 10 ** Math.floor(1 + Math.log10(p1));
+  ;;         p1/= z;
+  ;;       }
+
+  ;;       // Using Farey Sequences
+
+  ;;       while (B <= N && D <= N) {
+  ;;         let M = (A + C) / (B + D);
+
+  ;;         if (p1 === M) {
+  ;;           if (B + D <= N) {
+  ;;             n = A + C;
+  ;;             d = B + D;
+  ;;           } else if (D > B) {
+  ;;             n = C;
+  ;;             d = D;
+  ;;           } else {
+  ;;             n = A;
+  ;;             d = B;
+  ;;           }
+  ;;           break;
+
+  ;;         } else {
+
+  ;;           if (p1 > M) {
+  ;;             A+= C;
+  ;;             B+= D;
+  ;;           } else {
+  ;;             C+= A;
+  ;;             D+= B;
+  ;;           }
+
+  ;;           if (B > N) {
+  ;;             n = C;
+  ;;             d = D;
+  ;;           } else {
+  ;;             n = A;
+  ;;             d = B;
+  ;;           }
+  ;;         }
+  ;;       }
+  ;;       n = BigInt(n) * BigInt(z);
+  ;;       d = BigInt(d);
+
+  ;;     }
+
+  ;;   } else if (typeof p1 === "string") {
+
+  ;;     let ndx = 0;
+
+  ;;     let v = C_ZERO, w = C_ZERO, x = C_ZERO, y = C_ONE, z = C_ONE;
+
+  ;;     let match = p1.match(/\d+|./g);
+
+  ;;     if (match === null)
+  ;;       throw InvalidParameter();
+
+  ;;     if (match[ndx] === '-') {// Check for minus sign at the beginning
+  ;;       s = -C_ONE;
+  ;;       ndx++;
+  ;;     } else if (match[ndx] === '+') {// Check for plus sign at the beginning
+  ;;       ndx++;
+  ;;     }
+
+  ;;     if (match.length === ndx + 1) { // Check if it's just a simple number "1234"
+  ;;       w = assign(match[ndx++], s);
+  ;;     } else if (match[ndx + 1] === '.' || match[ndx] === '.') { // Check if it's a decimal number
+
+  ;;       if (match[ndx] !== '.') { // Handle 0.5 and .5
+  ;;         v = assign(match[ndx++], s);
+  ;;       }
+  ;;       ndx++;
+
+  ;;       // Check for decimal places
+  ;;       if (ndx + 1 === match.length || match[ndx + 1] === '(' && match[ndx + 3] === ')' || match[ndx + 1] === "'" && match[ndx + 3] === "'") {
+  ;;         w = assign(match[ndx], s);
+  ;;         y = C_TEN ** BigInt(match[ndx].length);
+  ;;         ndx++;
+  ;;       }
+
+  ;;       // Check for repeating places
+  ;;       if (match[ndx] === '(' && match[ndx + 2] === ')' || match[ndx] === "'" && match[ndx + 2] === "'") {
+  ;;         x = assign(match[ndx + 1], s);
+  ;;         z = C_TEN ** BigInt(match[ndx + 1].length) - C_ONE;
+  ;;         ndx+= 3;
+  ;;       }
+
+  ;;     } else if (match[ndx + 1] === '/' || match[ndx + 1] === ':') { // Check for a simple fraction "123/456" or "123:456"
+  ;;       w = assign(match[ndx], s);
+  ;;       y = assign(match[ndx + 2], C_ONE);
+  ;;       ndx+= 3;
+  ;;     } else if (match[ndx + 3] === '/' && match[ndx + 1] === ' ') { // Check for a complex fraction "123 1/2"
+  ;;       v = assign(match[ndx], s);
+  ;;       w = assign(match[ndx + 2], s);
+  ;;       y = assign(match[ndx + 4], C_ONE);
+  ;;       ndx+= 5;
+  ;;     }
+
+  ;;     if (match.length <= ndx) { // Check for more tokens on the stack
+  ;;       d = y * z;
+  ;;       s = /* void */
+  ;;       n = x + d * v + z * w;
+  ;;     } else {
+  ;;       throw InvalidParameter();
+  ;;     }
+
+  ;;   } else {
+  ;;     throw InvalidParameter();
+  ;;   }
+
+  ;;   if (d === C_ZERO) {
+  ;;     throw DivisionByZero();
+  ;;   }
+
+  ;;   P["s"] = s < C_ZERO ? -C_ONE : C_ONE;
+  ;;   P["n"] = n < C_ZERO ? -n : n;
+  ;;   P["d"] = d < C_ZERO ? -d : d;
+  ;; };
+
+(defn gcd [a b])
+;; function gcd(a, b) {
+
+;;                     if (!a)
+;;                     return b;
+;;                     if (!b)
+;;                     return a;
+
+;;                     while (1) {
+;;                                a%= b;
+;;                                if (!a)
+;;                                return b;
+;;                                b%= a;
+;;                                if (!b)
+;;                                return a;
+;;                                }
+;;                     }
+
+(defn new-fraction [])
+;; // Creates a new Fraction internally without the need of the bulky constructor
+;; function newFraction(n, d) {
+
+;;                             if (d === C_ZERO) {
+;;                                                throw DivisionByZero();
+;;                                                }
+
+;;                             const f = Object.create(Fraction.prototype);
+;;                             f["s"] = n < C_ZERO ? -C_ONE : C_ONE;
+
+;;                             n = n < C_ZERO ? -n : n;
+
+;;                             const a = gcd(n, d);
+
+;;                             f["n"] = n / a;
+;;                             f["d"] = d / a;
+;;                             return f;
+;;                             }
+
+(defn build [])
+;; function Fraction(a, b) {
+
+;;                          parse(a, b);
+
+;;                          if (this instanceof Fraction) {
+;;                                                         a = gcd(P["d"], P["n"]); // Abuse a
+;;                                                         this["s"] = P["s"];
+;;                                                         this["n"] = P["n"] / a;
+;;                                                         this["d"] = P["d"] / a;
+;;                                                         } else {
+;;                                                                 return newFraction(P['s'] * P['n'], P['d']);
+;;                                                                 }
+;;                          }
+
+
+(defn abs [x])
+;; /**
+;;      * Calculates the absolute value
+;;      *
+;;      * Ex: new Fraction(-4).abs() => 4
+;;      **/
+;;     "abs": function() {
+
+;;       return newFraction(this["n"], this["d"]);
+;;     },
+
+(defn neg [^Fraction x]
+  )
+;;     /**
+;;      * Inverts the sign of the current fraction
+;;      *
+;;      * Ex: new Fraction(-4).neg() => 4
+;;      **/
+;;     "neg": function() {
+
+;;       return newFraction(-this["s"] * this["n"], this["d"]);
+;;     },
+
+(defn add [^Fraction a ^Fraction b]
+  (Fraction. (* (.-s a))))
+;;     /**
+;;      * Adds two rational numbers
+;;      *
+;;      * Ex: new Fraction({n: 2, d: 3}).add("14.9") => 467 / 30
+;;      **/
+;;     "add": function(a, b) {
+
+;;       parse(a, b);
+;;       return newFraction(
+;;         this["s"] * this["n"] * P["d"] + P["s"] * this["d"] * P["n"],
+;;         this["d"] * P["d"]
+;;       );
+;;     },
+
+(defn sub [a b])
+;;     /**
+;;      * Subtracts two rational numbers
+;;      *
+;;      * Ex: new Fraction({n: 2, d: 3}).add("14.9") => -427 / 30
+;;      **/
+;;     "sub": function(a, b) {
+
+;;       parse(a, b);
+;;       return newFraction(
+;;         this["s"] * this["n"] * P["d"] - P["s"] * this["d"] * P["n"],
+;;         this["d"] * P["d"]
+;;       );
+;;     },
+
+(defn mul [a b])
+;;     /**
+;;      * Multiplies two rational numbers
+;;      *
+;;      * Ex: new Fraction("-17.(345)").mul(3) => 5776 / 111
+;;      **/
+;;     "mul": function(a, b) {
+
+;;       parse(a, b);
+;;       return newFraction(
+;;         this["s"] * P["s"] * this["n"] * P["n"],
+;;         this["d"] * P["d"]
+;;       );
+;;     },
+
+(defn div [a b])
+;;     /**
+;;      * Divides two rational numbers
+;;      *
+;;      * Ex: new Fraction("-17.(345)").inverse().div(3)
+;;      **/
+;;     "div": function(a, b) {
+
+;;       parse(a, b);
+;;       return newFraction(
+;;         this["s"] * P["s"] * this["n"] * P["d"],
+;;         this["d"] * P["n"]
+;;       );
+;;     },
+
+(defn clone [x])
+;;     /**
+;;      * Clones the actual object
+;;      *
+;;      * Ex: new Fraction("-17.(345)").clone()
+;;      **/
+;;     "clone": function() {
+;;       return newFraction(this['s'] * this['n'], this['d']);
+;;     },
+
+(defn mod [x])
+;;     /**
+;;      * Calculates the modulo of two rational numbers - a more precise fmod
+;;      *
+;;      * Ex: new Fraction('4.(3)').mod([7, 8]) => (13/3) % (7/8) = (5/6)
+;;      **/
+;;     "mod": function(a, b) {
+
+;;       if (a === undefined) {
+;;         return newFraction(this["s"] * this["n"] % this["d"], C_ONE);
+;;       }
+
+;;       parse(a, b);
+;;       if (0 === P["n"] && 0 === this["d"]) {
+;;         throw DivisionByZero();
+;;       }
+
+;;       /*
+;;        * First silly attempt, kinda slow
+;;        *
+;;        return that["sub"]({
+;;        "n": num["n"] * Math.floor((this.n / this.d) / (num.n / num.d)),
+;;        "d": num["d"],
+;;        "s": this["s"]
+;;        });*/
+
+;;       /*
+;;        * New attempt: a1 / b1 = a2 / b2 * q + r
+;;        * => b2 * a1 = a2 * b1 * q + b1 * b2 * r
+;;        * => (b2 * a1 % a2 * b1) / (b1 * b2)
+;;        */
+;;       return newFraction(
+;;         this["s"] * (P["d"] * this["n"]) % (P["n"] * this["d"]),
+;;         P["d"] * this["d"]
+;;       );
+;;     },
+
+(defn gcd [x])
+;;     /**
+;;      * Calculates the fractional gcd of two rational numbers
+;;      *
+;;      * Ex: new Fraction(5,8).gcd(3,7) => 1/56
+;;      */
+;;     "gcd": function(a, b) {
+
+;;       parse(a, b);
+
+;;       // gcd(a / b, c / d) = gcd(a, c) / lcm(b, d)
+
+;;       return newFraction(gcd(P["n"], this["n"]) * gcd(P["d"], this["d"]), P["d"] * this["d"]);
+;;     },
+
+(defn lcm [x])
+;;     /**
+;;      * Calculates the fractional lcm of two rational numbers
+;;      *
+;;      * Ex: new Fraction(5,8).lcm(3,7) => 15
+;;      */
+;;     "lcm": function(a, b) {
+
+;;       parse(a, b);
+
+;;       // lcm(a / b, c / d) = lcm(a, c) / gcd(b, d)
+
+;;       if (P["n"] === C_ZERO && this["n"] === C_ZERO) {
+;;         return newFraction(C_ZERO, C_ONE);
+;;       }
+;;       return newFraction(P["n"] * this["n"], gcd(P["n"], this["n"]) * gcd(P["d"], this["d"]));
+;;     },
+
+(defn inverse [x])
+;;     /**
+;;      * Gets the inverse of the fraction, means numerator and denominator are exchanged
+;;      *
+;;      * Ex: new Fraction([-3, 4]).inverse() => -4 / 3
+;;      **/
+;;     "inverse": function() {
+;;       return newFraction(this["s"] * this["d"], this["n"]);
+;;     },
+
+(defn pow [a b])
+;;     /**
+;;      * Calculates the fraction to some integer exponent
+;;      *
+;;      * Ex: new Fraction(-1,2).pow(-3) => -8
+;;      */
+;;     "pow": function(a, b) {
+
+;;       parse(a, b);
+
+;;       // Trivial case when exp is an integer
+
+;;       if (P['d'] === C_ONE) {
+
+;;         if (P['s'] < C_ZERO) {
+;;           return newFraction((this['s'] * this["d"]) ** P['n'], this["n"] ** P['n']);
+;;         } else {
+;;           return newFraction((this['s'] * this["n"]) ** P['n'], this["d"] ** P['n']);
+;;         }
+;;       }
+
+;;       // Negative roots become complex
+;;       //     (-a/b)^(c/d) = x
+;;       // <=> (-1)^(c/d) * (a/b)^(c/d) = x
+;;       // <=> (cos(pi) + i*sin(pi))^(c/d) * (a/b)^(c/d) = x
+;;       // <=> (cos(c*pi/d) + i*sin(c*pi/d)) * (a/b)^(c/d) = x       # DeMoivre's formula
+;;       // From which follows that only for c=0 the root is non-complex
+;;       if (this['s'] < C_ZERO) return null;
+
+;;       // Now prime factor n and d
+;;       let N = factorize(this['n']);
+;;       let D = factorize(this['d']);
+
+;;       // Exponentiate and take root for n and d individually
+;;       let n = C_ONE;
+;;       let d = C_ONE;
+;;       for (let k in N) {
+;;         if (k === '1') continue;
+;;         if (k === '0') {
+;;           n = C_ZERO;
+;;           break;
+;;         }
+;;         N[k]*= P['n'];
+
+;;         if (N[k] % P['d'] === C_ZERO) {
+;;           N[k]/= P['d'];
+;;         } else return null;
+;;         n*= BigInt(k) ** N[k];
+;;       }
+
+;;       for (let k in D) {
+;;         if (k === '1') continue;
+;;         D[k]*= P['n'];
+
+;;         if (D[k] % P['d'] === C_ZERO) {
+;;           D[k]/= P['d'];
+;;         } else return null;
+;;         d*= BigInt(k) ** D[k];
+;;       }
+
+;;       if (P['s'] < C_ZERO) {
+;;         return newFraction(d, n);
+;;       }
+;;       return newFraction(n, d);
+;;     },
+
+(defn equals [a b])
+;;     /**
+;;      * Check if two rational numbers are the same
+;;      *
+;;      * Ex: new Fraction(19.6).equals([98, 5]);
+;;      **/
+;;     "equals": function(a, b) {
+
+;;       parse(a, b);
+;;       return this["s"] * this["n"] * P["d"] === P["s"] * P["n"] * this["d"]; // Same as compare() === 0
+;;     },
+
+(defn compare [a b])
+;;     /**
+;;      * Check if two rational numbers are the same
+;;      *
+;;      * Ex: new Fraction(19.6).equals([98, 5]);
+;;      **/
+;;     "compare": function(a, b) {
+
+;;       parse(a, b);
+;;       let t = (this["s"] * this["n"] * P["d"] - P["s"] * P["n"] * this["d"]);
+
+;;       return (C_ZERO < t) - (t < C_ZERO);
+;;     },
+
+(defn ceil [x])
+;;     /**
+;;      * Calculates the ceil of a rational number
+;;      *
+;;      * Ex: new Fraction('4.(3)').ceil() => (5 / 1)
+;;      **/
+;;     "ceil": function(places) {
+
+;;       places = C_TEN ** BigInt(places || 0);
+
+;;       return newFraction(this["s"] * places * this["n"] / this["d"] +
+;;         (places * this["n"] % this["d"] > C_ZERO && this["s"] >= C_ZERO ? C_ONE : C_ZERO),
+;;         places);
+;;     },
+
+(defn floor [x])
+;;     /**
+;;      * Calculates the floor of a rational number
+;;      *
+;;      * Ex: new Fraction('4.(3)').floor() => (4 / 1)
+;;      **/
+;;     "floor": function(places) {
+
+;;       places = C_TEN ** BigInt(places || 0);
+
+;;       return newFraction(this["s"] * places * this["n"] / this["d"] -
+;;         (places * this["n"] % this["d"] > C_ZERO && this["s"] < C_ZERO ? C_ONE : C_ZERO),
+;;         places);
+;;     },
+
+(defn round [x])
+;;     /**
+;;      * Rounds a rational numbers
+;;      *
+;;      * Ex: new Fraction('4.(3)').round() => (4 / 1)
+;;      **/
+;;     "round": function(places) {
+
+;;       places = C_TEN ** BigInt(places || 0);
+
+;;       /* Derivation:
+
+;;       s >= 0:
+;;         round(n / d) = trunc(n / d) + (n % d) / d >= 0.5 ? 1 : 0
+;;                      = trunc(n / d) + 2(n % d) >= d ? 1 : 0
+;;       s < 0:
+;;         round(n / d) =-trunc(n / d) - (n % d) / d > 0.5 ? 1 : 0
+;;                      =-trunc(n / d) - 2(n % d) > d ? 1 : 0
+
+;;       =>:
+
+;;       round(s * n / d) = s * trunc(n / d) + s * (C + 2(n % d) > d ? 1 : 0)
+;;           where C = s >= 0 ? 1 : 0, to fix the >= for the positve case.
+;;       */
+
+;;       return newFraction(this["s"] * places * this["n"] / this["d"] +
+;;         this["s"] * ((this["s"] >= C_ZERO ? C_ONE : C_ZERO) + C_TWO * (places * this["n"] % this["d"]) > this["d"] ? C_ONE : C_ZERO),
+;;         places);
+;;     },
+
+(defn divisible [a b])
+;;     /**
+;;      * Check if two rational numbers are divisible
+;;      *
+;;      * Ex: new Fraction(19.6).divisible(1.5);
+;;      */
+;;     "divisible": function(a, b) {
+
+;;       parse(a, b);
+;;       return !(!(P["n"] * this["d"]) || ((this["n"] * P["d"]) % (P["n"] * this["d"])));
+;;     },
+
+(defn value-of [x])
+;;     /**
+;;      * Returns a decimal representation of the fraction
+;;      *
+;;      * Ex: new Fraction("100.'91823'").valueOf() => 100.91823918239183
+;;      **/
+;;     'valueOf': function() {
+;;       // Best we can do so far
+;;       return Number(this["s"] * this["n"]) / Number(this["d"]);
+;;     },
+
+
+(defn to-string [x])
+;; /**
+;;      * Creates a string representation of a fraction with all digits
+;;      *
+;;      * Ex: new Fraction("100.'91823'").toString() => "100.(91823)"
+;;      **/
+;;     'toString': function(dec) {
+
+;;       let N = this["n"];
+;;       let D = this["d"];
+
+;;       function trunc(x) {
+;;           return typeof x === 'bigint' ? x : Math.floor(x);
+;;       }
+
+;;       dec = dec || 15; // 15 = decimal places when no repetition
+
+;;       let cycLen = cycleLen(N, D); // Cycle length
+;;       let cycOff = cycleStart(N, D, cycLen); // Cycle start
+
+;;       let str = this['s'] < C_ZERO ? "-" : "";
+
+;;       // Append integer part
+;;       str+= trunc(N / D);
+
+;;       N%= D;
+;;       N*= C_TEN;
+
+;;       if (N)
+;;         str+= ".";
+
+;;       if (cycLen) {
+
+;;         for (let i = cycOff; i--;) {
+;;           str+= trunc(N / D);
+;;           N%= D;
+;;           N*= C_TEN;
+;;         }
+;;         str+= "(";
+;;         for (let i = cycLen; i--;) {
+;;           str+= trunc(N / D);
+;;           N%= D;
+;;           N*= C_TEN;
+;;         }
+;;         str+= ")";
+;;       } else {
+;;         for (let i = dec; N && i--;) {
+;;           str+= trunc(N / D);
+;;           N%= D;
+;;           N*= C_TEN;
+;;         }
+;;       }
+;;       return str;
+;;     },
+
+(defn to-fraction [x])
+;;     /**
+;;      * Returns a string-fraction representation of a Fraction object
+;;      *
+;;      * Ex: new Fraction("1.'3'").toFraction() => "4 1/3"
+;;      **/
+;;     'toFraction': function(excludeWhole) {
+
+;;       let n = this["n"];
+;;       let d = this["d"];
+;;       let str = this['s'] < C_ZERO ? "-" : "";
+
+;;       if (d === C_ONE) {
+;;         str+= n;
+;;       } else {
+;;         let whole = n / d;
+;;         if (excludeWhole && whole > C_ZERO) {
+;;           str+= whole;
+;;           str+= " ";
+;;           n%= d;
+;;         }
+
+;;         str+= n;
+;;         str+= '/';
+;;         str+= d;
+;;       }
+;;       return str;
+;;     },
+
+(defn to-latex [])
+;;     /**
+;;      * Returns a latex representation of a Fraction object
+;;      *
+;;      * Ex: new Fraction("1.'3'").toLatex() => "\frac{4}{3}"
+;;      **/
+;;     'toLatex': function(excludeWhole) {
+
+;;       let n = this["n"];
+;;       let d = this["d"];
+;;       let str = this['s'] < C_ZERO ? "-" : "";
+
+;;       if (d === C_ONE) {
+;;         str+= n;
+;;       } else {
+;;         let whole = n / d;
+;;         if (excludeWhole && whole > C_ZERO) {
+;;           str+= whole;
+;;           n%= d;
+;;         }
+
+;;         str+= "\\frac{";
+;;         str+= n;
+;;         str+= '}{';
+;;         str+= d;
+;;         str+= '}';
+;;       }
+;;       return str;
+;;     },
+
+(defn to-continued [])
+;;     /**
+;;      * Returns an array of continued fraction elements
+;;      *
+;;      * Ex: new Fraction("7/8").toContinued() => [0,1,7]
+;;      */
+;;     'toContinued': function() {
+
+;;       let a = this['n'];
+;;       let b = this['d'];
+;;       let res = [];
+
+;;       do {
+;;         res.push(a / b);
+;;         let t = a % b;
+;;         a = b;
+;;         b = t;
+;;       } while (a !== C_ONE);
+
+;;       return res;
+;;     },
+
+(defn simplify [])
+
+;;     "simplify": function(eps) {
+
+;;       eps = eps || 0.001;
+
+;;       const thisABS = this['abs']();
+;;       const cont = thisABS['toContinued']();
+
+;;       for (let i = 1; i < cont.length; i++) {
+
+;;         let s = newFraction(cont[i - 1], C_ONE);
+;;         for (let k = i - 2; k >= 0; k--) {
+;;           s = s['inverse']()['add'](cont[k]);
+;;         }
+
+;;         if (Math.abs(s['sub'](thisABS).valueOf()) < eps) {
+;;           return s['mul'](this['s']);
+;;         }
+;;       }
+;;       return this;
+;;     }
+;;   };

--- a/src/emmy/complex/impl.cljc
+++ b/src/emmy/complex/impl.cljc
@@ -20,7 +20,7 @@
             [emmy.util :as u]
             [emmy.value :as v]))
 
-(declare equal?)
+(declare equal? ->string)
 
 (deftype Complex [re im]
   v/IKind
@@ -32,23 +32,24 @@
   (numerical? [_] true)
 
   #?@(:clj [Object
-            (equals [a b] (equal? a b))]
+            (equals [a b] (equal? a b))
+            (toString [a] (->string a))]
+
       :cljs [IEquiv
              (-equiv [a b] (equal? a b))
 
              IPrintWithWriter
              (-pr-writer
               [z writer _]
-              (write-all
-               writer
-               "#emmy/complex "
-               (str [(.-re z) (.-im z)])))]))
+              (write-all writer (->string z)))]))
 
 #?(:clj
-   (defmethod print-method Complex [^Complex v ^java.io.Writer w]
-     (.write w (str "#emmy/complex "
-                    [(.-re v)
-                     (.-im v)]))))
+   (defmethod print-method Complex [^Complex z ^java.io.Writer w]
+     (.write w (->string z))))
+
+(defn- ->string
+  [^Complex c]
+  (str "#emmy/complex " [(.-re c) (.-im c)]))
 
 (def ZERO (Complex. 0 0))
 (def ONE (Complex. 1 0))

--- a/src/emmy/complex/impl.cljc
+++ b/src/emmy/complex/impl.cljc
@@ -35,7 +35,10 @@
             (equals [a b] (equal? a b))
             (toString [a] (->string a))]
 
-      :cljs [IEquiv
+      :cljs [Object
+             (toString [a] (->string a))
+
+             IEquiv
              (-equiv [a b] (equal? a b))
 
              IPrintWithWriter

--- a/src/emmy/ratio.cljc
+++ b/src/emmy/ratio.cljc
@@ -12,23 +12,20 @@
   (:refer-clojure :exclude [ratio? numerator denominator rationalize])
   (:require #?(:clj [clojure.core :as core])
             #?(:clj [clojure.edn] :cljs [cljs.reader])
-            #?(:cljs ["fraction.js/bigfraction.js" :as Fraction])
-            #?(:cljs [emmy.complex :as c])
-            #?(:cljs [goog.array :as garray])
-            #?(:cljs [goog.object :as obj])
+            #?(:cljs [emmy.bigfraction :as bf])
             [emmy.generic :as g]
             [emmy.util :as u]
             [emmy.value :as v])
   #?(:clj (:import (clojure.lang Ratio))))
 
 (def ^:no-doc ratiotype
-  #?(:clj Ratio :cljs Fraction))
+  #?(:clj Ratio :cljs ::ratio))
 
 (derive ratiotype ::v/real)
 
 (def ratio?
   #?(:clj core/ratio?
-     :cljs (fn [r] (instance? Fraction r))))
+     :cljs (fn [r] (instance? bf/Fraction r))))
 
 (defprotocol IRational
   (numerator [_])
@@ -45,52 +42,23 @@
        (denominator [r] (core/denominator r))]
 
       :cljs
-      [Fraction
-       (numerator
-        [x]
-        (if (pos? (obj/get x "s"))
-          (obj/get x "n")
-          (- (obj/get x "n"))))
-       (denominator
-        [x]
-        (obj/get x "d"))]))
-
-#?(:cljs
-   (defn- promote [x]
-     (if (g/one? (denominator x))
-       (numerator x)
-       x)))
+      [bf/Fraction
+       (numerator [x] (bf/numerator x))
+       (denominator [x] (bf/denominator x))]))
 
 (defn rationalize
   "Construct a ratio."
   ([x]
-   #?(:cljs (if (v/integral? x)
-              x
-              (Fraction. x))
+   #?(:cljs (cond (v/integral? x) x
+                  (instance? bf/Fraction x) x
+                  (v/real? x) (bf/real-> x)
+                  :else (u/arithmetic-ex (str "Cannot rationalize " x)))
       :clj (core/rationalize x)))
   ([n d]
-   #?(:cljs (if (g/one? d)
-              n
-              (promote (Fraction. n d)))
+   #?(:cljs (bf/promote (bf/make n d))
       :clj (core/rationalize (/ n d)))))
 
-(def ^:private ratio-pattern #"([-+]?[0-9]+)/([0-9]+)")
-
-(defn matches? [pattern s]
-  (let [[match] (re-find pattern s)]
-    (identical? match s)))
-
-(defn ^:private match-ratio
-  [s]
-  (let [m (vec (re-find ratio-pattern s))
-        numerator   (m 1)
-        denominator (m 2)
-        numerator (if (re-find #"^\+" numerator)
-                    (subs numerator 1)
-                    numerator)]
-    `(rationalize
-      (u/bigint ~numerator)
-      (u/bigint ~denominator))))
+(def ^:private ratio-pattern #"(-?\d+)/(\d+)")
 
 (defn parse-ratio
   "Parser for the `#emmy/ratio` literal."
@@ -102,93 +70,28 @@
                (u/bigint ~(str (denominator x))))])
 
         (v/number? x) `(emmy.ratio/rationalize ~x)
-        (string? x)    (if (matches? ratio-pattern x)
-                         (match-ratio x)
-                         (recur
-                          #?(:clj  (clojure.edn/read-string x)
-                             :cljs (cljs.reader/read-string x))))
+        (string? x)    (if-let [[_ numerator denominator] (re-matches ratio-pattern x)]
+                         `(rationalize (u/bigint ~numerator) (u/bigint ~denominator))
+                         (u/illegal (str "Invalid ratio: " x)))
+        (and (vector? x) (= 2 (count x))) `(rationalize ~@x)
+
         :else (u/illegal (str "Invalid ratio: " x))))
 
+(defmethod g/exact? [ratiotype] [_] true)
+(defmethod g/freeze [ratiotype] [x]
+  (let [n (numerator x)
+        d (denominator x)]
+    (if (g/one? d)
+      n
+      `(~'/ ~(g/freeze n) ~(g/freeze d)))))
+
 #?(:clj
-   (do
-     (defmethod g/exact? [Ratio] [_] true)
-     (defmethod g/freeze [Ratio] [x]
-       (let [n (numerator x)
-             d (denominator x)]
-         (if (g/one? d)
-           n
-           `(~'/ ~n ~d))))
-     (extend-type Ratio
-       v/Numerical
-       (numerical? [_] true)
+   (extend-type Ratio
+     v/Numerical
+     (numerical? [_] true)
 
-       v/IKind
-       (kind [_] Ratio)))
-
-   :cljs
-   (do
-     (defmethod g/exact? [Fraction] [_] true)
-     (defmethod g/freeze [Fraction] [x]
-       (let [n (numerator x)
-             d (denominator x)]
-         (if (g/one? d)
-           (g/freeze n)
-           `(~'/
-             ~(g/freeze n)
-             ~(g/freeze d)))))
-     (extend-type Fraction
-       v/Numerical
-       (numerical? [_] true)
-
-       v/IKind
-       (kind [_] Fraction)
-
-       IEquiv
-       (-equiv [this other]
-         (cond (ratio? other) (.equals this other)
-               (v/integral? other)
-               (and (g/one? (denominator this))
-                    (v/= (numerator this) other))
-
-               ;; Enabling this would work, but would take us away from
-               ;; Clojure's behavior.
-               #_(v/number? other)
-               #_(.equals this (rationalize other))
-
-               :else false))
-
-       IComparable
-       (-compare [this other]
-         (if (ratio? other)
-           (.compare this other)
-           (let [o-value (.valueOf other)]
-             (if (v/real? o-value)
-               (garray/defaultCompare this o-value)
-               (throw (js/Error. (str "Cannot compare " this " to " other)))))))
-
-       IHash
-       (-hash [this]
-         (bit-xor
-          (-hash (numerator this))
-          (-hash (denominator this))))
-
-       Object
-       (toString [r]
-         (let [x (g/freeze r)]
-           (if (number? x)
-             x
-             (let [[_ n d] x]
-               (str n "/" d)))))
-
-       IPrintWithWriter
-       (-pr-writer [x writer opts]
-         (let [n (numerator x)
-               d (denominator x)]
-           (if (g/one? d)
-             (-pr-writer n writer opts)
-             (write-all writer "#emmy/ratio \""
-                        (str n) "/" (str d)
-                        "\"")))))))
+     v/IKind
+     (kind [_] Ratio)))
 
 #?(:clj
    (do
@@ -219,8 +122,7 @@
        (defmethod op [::v/integral Ratio] [a b] (f a b))))
 
    :cljs
-   (let [ZERO (Fraction. 0)
-         ONE  (Fraction. 1)]
+   (do
      (defn- pow [r m]
        (let [n (numerator r)
              d (denominator r)]
@@ -232,95 +134,81 @@
 
      ;; The -equiv implementation handles equality with any number, so flip the
      ;; arguments around and invoke equiv.
-     (defmethod v/= [::v/real Fraction] [l r] (= r l))
+     (defmethod v/= [::v/real ::ratio] [l r] (= r l))
 
-     (defmethod g/add [Fraction Fraction] [a b] (promote (.add ^js a b)))
-     (defmethod g/sub [Fraction Fraction] [a b] (promote (.sub ^js a b)))
+     ;; Note that fraction arithmetic automatically downcasts integral results
+     ;; to the underlying bigint type.
+     (defmethod g/add [::ratio ::ratio] [a b] (bf/promote (bf/add a b)))
+     (defmethod g/sub [::ratio ::ratio] [a b] (bf/promote (bf/sub a b)))
+     (defmethod g/mul [::ratio ::ratio] [a b] (bf/promote (bf/mul a b)))
+     (defmethod g/div [::ratio ::ratio] [a b] (bf/promote (bf/div a b)))
+     (defmethod g/exact-divide [::ratio ::ratio] [a b] (bf/promote (bf/div a b)))
 
-     (defmethod g/mul [Fraction Fraction] [a b]
-       (promote (.mul ^js a b)))
+     ;; In principle, one should not find an integral fraction object in the wild
+     ;; due to the automatic downcasting. In theory the following three could just
+     ;; return false, but let's test for a while with some assert statements.
+     ;;
+     (defmethod g/zero? [::ratio] [c] (bf/zero? c))
+     (defmethod g/one? [::ratio] [c] (bf/one? c))
+     (defmethod g/identity? [::ratio] [c] (bf/one? c))
+     (defmethod g/zero-like [::ratio] [_] 0)
+     (defmethod g/one-like [::ratio] [_] 1)
+     (defmethod g/identity-like [::ratio] [_] 1)
 
-     (defmethod g/div [Fraction Fraction] [a b]
-       (promote (.div ^js a b)))
+     (defmethod g/negate [::ratio] [a] (bf/promote (bf/neg a)))
+     (defmethod g/negative? [::ratio] [a] (bf/neg? a))
+     (defmethod g/infinite? [::ratio] [_] false)
+     (defmethod g/invert [::ratio] [a] (bf/promote (bf/invert a)))
+     (defmethod g/square [::ratio] [a] (bf/promote (bf/mul a a)))
+     (defmethod g/cube [::ratio] [a] (bf/promote (bf/integer-power a 3)))
+     (defmethod g/abs [::ratio] [a] (bf/promote (bf/abs a)))
+     (defmethod g/magnitude [::ratio] [a] (bf/promote (bf/abs a)))
 
-     (defmethod g/exact-divide [Fraction Fraction] [a b]
-       (promote (.div ^js a b)))
+     (defmethod g/expt [::ratio ::v/integral] [a b] (bf/promote (bf/integer-power a b)))
+     (defmethod g/expt [::ratio ::ratio] [a b]
+       (bf/promote
+        (if (g/one? (bf/denominator b))
+          (bf/integer-power a (bf/numerator b))
+          (g/expt (bf/->real a) (bf/->real b)))))
 
-     (defmethod g/zero? [Fraction] [^Fraction c] (.equals c ZERO))
-     (defmethod g/one? [Fraction] [^Fraction c] (.equals c ONE))
-     (defmethod g/identity? [Fraction] [^Fraction c] (.equals c ONE))
-     (defmethod g/zero-like [Fraction] [_] 0)
-     (defmethod g/one-like [Fraction] [_] 1)
-     (defmethod g/identity-like [Fraction] [_] 1)
-
-     (defmethod g/negate [Fraction] [a] (promote (.neg ^js a)))
-     (defmethod g/negative? [Fraction] [a] (neg? (obj/get a "s")))
-     (defmethod g/infinite? [Fraction] [_] false)
-     (defmethod g/invert [Fraction] [a] (promote (.inverse ^js a)))
-     (defmethod g/square [Fraction] [a] (promote (.mul ^js a a)))
-     (defmethod g/cube [Fraction] [a] (promote (.pow ^js a 3)))
-     (defmethod g/abs [Fraction] [a] (promote (.abs ^js a)))
-     (defmethod g/magnitude [Fraction] [a] (promote (.abs ^js a)))
-
-     (defmethod g/gcd [Fraction Fraction] [a b]
-       (promote (.gcd ^js a b)))
-
-     (defmethod g/lcm [Fraction Fraction] [a b]
-       (promote (.lcm ^js a b)))
-
-     (defmethod g/expt [Fraction ::v/integral] [a b] (pow a b))
-     (defmethod g/sqrt [Fraction] [a]
+     (defmethod g/sqrt [::ratio] [a]
        (if (neg? a)
-         (g/sqrt (c/complex (.valueOf a)))
-         (g/div (g/sqrt (u/double (numerator a)))
-                (g/sqrt (u/double (denominator a))))))
+         (g/sqrt (bf/->real a))
+         (g/div (g/sqrt (numerator a))
+                (g/sqrt (denominator a)))))
 
-     (defmethod g/modulo [Fraction Fraction] [a b]
-       (promote
-        (.mod (.add (.mod ^js a b) b) b)))
+     (defmethod g/quotient [::ratio ::ratio] [a b] (bf/promote (bf/quotient a b)))
+     (defmethod g/remainder [::ratio ::ratio] [a b] (bf/promote (bf/remainder a b)))
+     (defmethod g/modulo [::ratio ::ratio] [a b]
+       (bf/promote
+        (bf/remainder (bf/add (bf/remainder a b) b) b)))
+     (defmethod g/gcd [::ratio ::ratio] [a b] (bf/promote (bf/gcd a b)))
 
-     ;; Only integral ratios let us stay exact. If a ratio appears in the
-     ;; exponent, convert the base to a number and call g/expt again.
-     (defmethod g/expt [Fraction Fraction] [a b]
-       (if (g/one? (denominator b))
-         (promote (.pow ^js a (numerator b)))
-         (g/expt (.valueOf a)
-                 (.valueOf b))))
-
-     (defmethod g/quotient [Fraction Fraction] [a b]
-       (promote
-        (let [x (.div ^js a b)]
-          (if (pos? (obj/get x "s"))
-            (.floor ^js x)
-            (.ceil ^js x)))))
-
-     (defmethod g/remainder [Fraction Fraction] [a b]
-       (promote (.mod ^js a b)))
-
-     ;; Cross-compatibility with numbers in CLJS.
+;; Cross-compatibility with numbers in CLJS.
      (defn- downcast-fraction
        "Anything that `upcast-number` doesn't catch will hit this and pull a floating
-  point value out of the ratio."
+        point value out of the ratio."
        [op]
-       (defmethod op [Fraction ::v/real] [a b]
-         (op (.valueOf ^js a) b))
+       (defmethod op [::ratio ::v/real] [a b]
+         (op (bf/->real a) b))
 
-       (defmethod op [::v/real Fraction] [a b]
-         (op a (.valueOf ^js b))))
+       (defmethod op [::v/real ::ratio] [a b]
+         (op a (bf/->real b))))
 
      (defn- upcast-number
        "Integrals can stay exact, so they become ratios before op."
        [op]
-       (defmethod op [Fraction ::v/integral] [a b]
-         (op a (Fraction. b 1)))
+       (defmethod op [::ratio ::v/integral] [a b]
+         (op a (bf/integer-> b)))
 
-       (defmethod op [::v/integral Fraction] [a b]
-         (op (Fraction. a 1) b)))
+       (defmethod op [::v/integral ::ratio] [a b]
+         (op (bf/integer-> a) b)))
 
      ;; An exact number should become a ratio rather than erroring out, if one
      ;; side of the calculation is already rational (but not if neither side
      ;; is).
      (upcast-number g/exact-divide)
+     (upcast-number g/gcd)
 
      ;; We handle the cases above where the exponent connects with integrals and
      ;; stays exact.

--- a/src/emmy/ratio.cljc
+++ b/src/emmy/ratio.cljc
@@ -123,15 +123,6 @@
 
    :cljs
    (do
-     (defn- pow [r m]
-       (let [n (numerator r)
-             d (denominator r)]
-         (if (neg? m)
-           (rationalize (g/expt d (g/negate m))
-                        (g/expt n (g/negate m)))
-           (rationalize (g/expt n m)
-                        (g/expt d m)))))
-
      ;; The -equiv implementation handles equality with any number, so flip the
      ;; arguments around and invoke equiv.
      (defmethod v/= [::v/real ::ratio] [l r] (= r l))

--- a/src/emmy/value.cljc
+++ b/src/emmy/value.cljc
@@ -9,7 +9,8 @@
   for a detailed discussion of how to use and extend the generic operations
   defined in [[emmy.generic]] and [[emmy.value]]."
   (:refer-clojure :exclude [zero? number? = compare])
-  (:require #?@(:cljs [[emmy.util :as u]
+  (:require #?@(:cljs [[emmy.bigfraction :as bf]
+                       [emmy.util :as u]
                        [goog.array :as garray]
                        [goog.object :as gobject]
                        [goog.math.Long]
@@ -84,6 +85,7 @@
   #?(:clj (instance? Number x)
      :cljs (or (cljs.core/number? x)
                (satisfies? IReal x)
+               (instance? bf/Fraction x)
                (instance? goog.math.Integer x)
                (instance? goog.math.Long x)
                (core/= "bigint" (goog/typeOf x)))))

--- a/src/emmy/value.cljc
+++ b/src/emmy/value.cljc
@@ -9,8 +9,7 @@
   for a detailed discussion of how to use and extend the generic operations
   defined in [[emmy.generic]] and [[emmy.value]]."
   (:refer-clojure :exclude [zero? number? = compare])
-  (:require #?@(:cljs [["fraction.js/bigfraction.js" :as Fraction]
-                       [emmy.util :as u]
+  (:require #?@(:cljs [[emmy.util :as u]
                        [goog.array :as garray]
                        [goog.object :as gobject]
                        [goog.math.Long]
@@ -30,6 +29,8 @@
    structure that should be preserved."))
 
 (defprotocol INumericTower)
+
+(defprotocol IReal)
 
 (extend-protocol Numerical
   #?(:clj Object :cljs default)
@@ -82,10 +83,11 @@
   [x]
   #?(:clj (instance? Number x)
      :cljs (or (cljs.core/number? x)
+               (satisfies? INumericTower x)
+               (satisfies? IReal x)
                (instance? goog.math.Integer x)
                (instance? goog.math.Long x)
-               (core/= "bigint" (goog/typeOf x))
-               (instance? Fraction x))))
+               (core/= "bigint" (goog/typeOf x)))))
 
 (defn number?
   "Returns true if `x` is any number type in the numeric tower:
@@ -93,18 +95,18 @@
   - integral
   - floating point
   - complex
+  - fraction
 
   false otherwise."
   [x]
   #?(:clj
      (or (instance? Number x)
-         (instance? emmy.value.INumericTower x))
+         (satisfies? INumericTower x))
      :cljs (or (cljs.core/number? x)
                (core/= "bigint" (goog/typeOf x))
-               (instance? Fraction x)
                (instance? goog.math.Integer x)
                (instance? goog.math.Long x)
-               (satisfies? emmy.value.INumericTower x))))
+               (satisfies? INumericTower x))))
 
 ;; `::scalar` is a thing that symbolic expressions AND actual numbers both
 ;; derive from.

--- a/src/emmy/value.cljc
+++ b/src/emmy/value.cljc
@@ -83,7 +83,6 @@
   [x]
   #?(:clj (instance? Number x)
      :cljs (or (cljs.core/number? x)
-               (satisfies? INumericTower x)
                (satisfies? IReal x)
                (instance? goog.math.Integer x)
                (instance? goog.math.Long x)

--- a/src/emmy/value.cljc
+++ b/src/emmy/value.cljc
@@ -84,11 +84,10 @@
   [x]
   #?(:clj (instance? Number x)
      :cljs (or (cljs.core/number? x)
-               (satisfies? IReal x)
-               (instance? bf/Fraction x)
                (instance? goog.math.Integer x)
                (instance? goog.math.Long x)
-               (core/= "bigint" (goog/typeOf x)))))
+               (core/= "bigint" (goog/typeOf x))
+               (instance? bf/Fraction x))))
 
 (defn number?
   "Returns true if `x` is any number type in the numeric tower:
@@ -102,11 +101,12 @@
   [x]
   #?(:clj
      (or (instance? Number x)
-         (satisfies? INumericTower x))
+         (instance? emmy.value.INumericTower x))
      :cljs (or (cljs.core/number? x)
-               (core/= "bigint" (goog/typeOf x))
                (instance? goog.math.Integer x)
                (instance? goog.math.Long x)
+               (core/= "bigint" (goog/typeOf x))
+               (instance? bf/Fraction x)
                (satisfies? INumericTower x))))
 
 ;; `::scalar` is a thing that symbolic expressions AND actual numbers both

--- a/test/emmy/abstract/number_test.cljc
+++ b/test/emmy/abstract/number_test.cljc
@@ -131,12 +131,9 @@
                  (is (not (v/real? wrapped)))
                  (is (v/real? (.valueOf wrapped)))
                  (if (r/ratio? n)
-                   (is (not= n (.valueOf wrapped))
-                       "ratios turn into doubles when you call valueOf, so
-                           the passthrough valueOf on literal-number kills
-                           equality.")
-                   (is (= n (.valueOf wrapped))
-                       "other real numbers respond the same way."))
+                   (is (ish? n (.valueOf wrapped))
+                       "valueOf will force a rational to a double, but it should be pretty close.")
+                   (is (= n (.valueOf wrapped))))
 
                  (is (= (.valueOf n) (.valueOf wrapped))
                      "valueOf on both sides always matches.")))))

--- a/test/emmy/complex_test.cljc
+++ b/test/emmy/complex_test.cljc
@@ -133,6 +133,10 @@
         (gt/integral-tests c/complex :exclusions skip :eq near)
         (gt/floating-point-tests c/complex :eq near)))
 
+    (testing "printing"
+      (is (= "#emmy/complex [1 -1]" (pr-str (c/complex 1 -1))))
+      (is (= "#emmy/complex [1 -1]" (.toString (c/complex 1 -1)))))
+
     (checking "g/negative?, g/infinite?" 100 [x sg/real]
               (let [z (c/complex x 0)]
                 (is (= (g/negative? x)

--- a/test/emmy/expression_test.cljc
+++ b/test/emmy/expression_test.cljc
@@ -160,8 +160,11 @@
       (is (= 0 (e/compare () ()))))
 
     (testing "for types that don't play nice we resort to hashing."
-      (is (= -1 (e/compare '(+ x y) #emmy/complex "1+2i")))
-      (is (= 1 (e/compare #emmy/complex "1+2i" '(+ x y)))))))
+      (let [ab (e/compare '(+ x y) #emmy/complex "1+2i")
+            ba (e/compare #emmy/complex "1+2i" '(+ x y))]
+        (is (not= ab 0))
+        (is (not= ba 0))
+        (is (neg? (* ab ba)))))))
 
     ;; TODO add more tests as we start to explore this function.
 

--- a/test/emmy/generators.cljc
+++ b/test/emmy/generators.cljc
@@ -5,6 +5,7 @@
   (:refer-clojure :exclude [bigint biginteger double long symbol])
   (:require [clojure.core :as core]
             [clojure.test.check.generators :as gen]
+            #?(:cljs [emmy.bigfraction :refer [Fraction]])
             [emmy.complex :as c]
             #?(:cljs [emmy.complex.impl :refer [Complex]])
             [emmy.differential :as d]
@@ -430,7 +431,7 @@
 
 (extend-protocol si/Approximate
   #?@(:cljs
-      [r/ratiotype
+      [Fraction
        (ish [this that] (eq-delegate this that))
 
        u/inttype

--- a/test/emmy/generic_test.cljc
+++ b/test/emmy/generic_test.cljc
@@ -176,9 +176,7 @@
 
 (defn ^:private is* [eq actual expected]
   (is (eq actual expected)
-      #?(:clj (format "expected: %s\n  actual: %s"
-                      (pr-str expected)
-                      (pr-str actual)))))
+      (str "expected: " (pr-str expected) "\n  actual: " (pr-str actual))))
 
 (defn integral-unary-tests
   [int->a & {:keys [exclusions eq]

--- a/test/emmy/ratio_test.cljc
+++ b/test/emmy/ratio_test.cljc
@@ -39,7 +39,6 @@
   (testing "r/parse-ratio can round-trip Ratio instances in clj or cljs. "
     #?(:clj
        (is (= #emmy/ratio "10/3"
-              #emmy/ratio "+10/3"
               #emmy/ratio [10 3]
               (read-string {:readers {'emmy/ratio r/parse-ratio}}
                            (pr-str #emmy/ratio 10/3)))

--- a/test/emmy/ratio_test.cljc
+++ b/test/emmy/ratio_test.cljc
@@ -40,7 +40,7 @@
     #?(:clj
        (is (= #emmy/ratio "10/3"
               #emmy/ratio "+10/3"
-              #emmy/ratio 10/3
+              #emmy/ratio [10 3]
               (read-string {:readers {'emmy/ratio r/parse-ratio}}
                            (pr-str #emmy/ratio 10/3)))
            "Ratio parses from numbers and strings.")

--- a/test/emmy/ratio_test.cljc
+++ b/test/emmy/ratio_test.cljc
@@ -42,7 +42,7 @@
               #emmy/ratio [10 3]
               (read-string {:readers {'emmy/ratio r/parse-ratio}}
                            (pr-str #emmy/ratio 10/3)))
-           "Ratio parses from numbers and strings.")
+           "Ratio parses from strings and vectors.")
        :cljs (is (= `(r/rationalize
                       (u/bigint "10")
                       (u/bigint "3"))
@@ -55,7 +55,14 @@
                       (u/bigint "999999999999999999999999")))
            (read-string {:readers {'emmy/ratio r/parse-ratio}}
                         (pr-str #emmy/ratio "1/999999999999999999999999")))
-        "Parsing #emmy/ratio works with big strings too.")))
+        "Parsing #emmy/ratio works with big strings too."))
+  (testing "expected ratio parse failures"
+    (is (thrown? #?(:clj IllegalArgumentException :cljs js/Error)
+                 (r/parse-ratio [1 2 3])))
+    (is (thrown? #?(:clj IllegalArgumentException :cljs js/Error)
+                 (r/parse-ratio 'foo)))
+    (is (thrown? #?(:clj IllegalArgumentException :cljs js/Error)
+                 (r/parse-ratio "1/2/3")))))
 
 (deftest rationalize-test
   (testing "r/rationalize promotes to bigint if evenly divisible"

--- a/test/emmy/simplify_test.cljc
+++ b/test/emmy/simplify_test.cljc
@@ -38,7 +38,7 @@
 
 (deftest simplify-expressions
   (is (= 6 (simplify-expression '(* 1 2 3))))
-  (is (= #emmy/ratio 2/3
+  (is (= #emmy/ratio "2/3"
          (simplify-expression '(/ 2 3)))))
 
 (deftest trivial-simplifications


### PR DESCRIPTION
A minimal set of arbitrary precision rationals is built on a pair of native JS BigInts. Rather than manage a general fraction field over some Euclidean domain, it was decided to produce something very similar to Clojure's native Ratio type.

Unusually for an Emmy file, the implementation is ClojureScript only; the main technicality in this library is preserving the BigInt-compatibility of the arithmetic operations done. 