### PR TITLE
fix(extend-type): use bigint instead of BigInt

### DIFF
--- a/src/emmy/value.cljc
+++ b/src/emmy/value.cljc
@@ -242,7 +242,7 @@
            (= this (.valueOf other)))))))
 
 #?(:cljs
-   (extend-type js/BigInt
+   (extend-type bigint
      IHash
      (-hash [this] (hash (.toString this 16)))
 
@@ -288,7 +288,7 @@
            (garray/defaultCompare this other)
            (throw (js/Error. (str "Cannot compare " this " to " o))))))
 
-     js/BigInt
+     bigint
      (-compare [this o]
        (let [other (.valueOf o)]
          (if (real? other)
@@ -313,7 +313,7 @@
    ;; ClojureScript-specific implementations of Value.
    (do
      (extend-protocol Numerical
-       js/BigInt
+       bigint
        (numerical? [_] true)
 
        goog.math.Integer
@@ -323,7 +323,7 @@
        (numerical? [_] true))
 
      (extend-protocol IKind
-       js/BigInt
+       bigint
        (kind [_] js/BigInt)
 
        goog.math.Integer


### PR DESCRIPTION
I was seeing this warning on recent cljs:

```
WARNING: Extending an existing JavaScript type - use a different symbol name instead of js/BigInt
```

Using `bigint` instead of `js/BigInt` when extending types/protocols eliminates this warning. via @shaunlebron:

> The "function", "object", "array" symbols are just symbols that have meaning in the context of the `extend-type` macro, so nothing special syntactically. They just map internally to the type strings produced by `goog/typeOf`, used for protocol dispatch.

I verified that `(goog/typeOf (js/BigInt 1))` => "bigint"

Discussion: https://groups.google.com/g/clojurescript/c/MKEZ9CBU77o?pli=1