### PR TITLE
Fix broken ns reference in defgeneric

### DIFF
--- a/src/emmy/util/def.cljc
+++ b/src/emmy/util/def.cljc
@@ -86,7 +86,7 @@
        (defmulti ~f
          ~docstring
          {:arglists '~(arglists a b)}
-         v/argument-kind ~@options)
+         emmy.value/argument-kind ~@options)
        (defmethod ~f [~kwd-klass] [k#]
          (~attr k#)))))
 


### PR DESCRIPTION
The current implementation relies on the macroexpansion site having `emmy.value` aliased to `v`.

I suppose we could also explicitly require emmy.value in this namespace, which lets the syntax-quote macro properly substitute it, but there could be circular dependencies I'm not aware of.