### PR TITLE
Add extract-id implementations for all types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,10 @@
   - simplifies the `emmy.tape/gradient` implementation down to only handle
     single real-or-structural arguments, just like `emmy.dual/derivative`. We'll
     share the "handle-multiple-input" implementation between the two in a
-    follow-up PR.
+    follow-up PR
+
+  - makes the tests in `emmy.calculus.derivative` generic on the derivative
+    implementation, so we can run all tests in forward and reverse mode.
 
 - #182:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,23 @@
 
 ## [unreleased]
 
+- #183:
+
+  - adds `emmy.{autodiff, tape}` to `emmy.sci`'s exported namespace set
+
+  - adds `emmy.dual/extract-id` implementations for all supported output types
+    (every type that already implements `emmy.dual/IPerturbed`)
+
+  - moves `emmy.tape/Completed` to `emmy.dual/Completed`; it doesn't really make
+    sense there, but this is the only current way to remove the circular
+    dependency between `emmy.dual` and `emmy.tape`. (`tape` needs a `dual`
+    import to gain `emmy.dual/IPerturbed`.)
+
+  - simplifies the `emmy.tape/gradient` implementation down to only handle
+    single real-or-structural arguments, just like `emmy.dual/derivative`. We'll
+    share the "handle-multiple-input" implementation between the two in a
+    follow-up PR.
+
 - #182:
 
   - moves the generic implementations for `TapeCell` and `Dual` to `emmy.autodiff`

--- a/src/emmy/abstract/number.cljc
+++ b/src/emmy/abstract/number.cljc
@@ -219,12 +219,12 @@
   (memoize g/simplify))
 
 (defn ^:no-doc simplify-numerical-expression
-  "This function will only simplify instances of [[expression/Literal]]; if `x` is
-  of that type, [[simplify-numerical-expression]] acts as a memoized version
-  of [[generic/simplify]]. Else, acts as identity.
+  "This function will only simplify instances of [[emmy.expression/Literal]]; if
+  `x` is of that type, [[simplify-numerical-expression]] acts as a memoized
+  version of [[generic/simplify]]. Else, acts as identity.
 
-  This trick is used in [[emmy.calculus.manifold]] to memoize
-  simplification _only_ for non-[[differential/Differential]] types."
+  This trick is used in [[emmy.calculus.manifold]] to memoize simplification
+  _only_ for non-perturbed types."
   [x]
   (if (literal-number? x)
     (memoized-simplify x)

--- a/src/emmy/collection.cljc
+++ b/src/emmy/collection.cljc
@@ -53,7 +53,7 @@
   f/IArity
   (arity [_] [:between 1 2])
 
-  ;; [[d/replace-tag]] and [[d/extract-tangent]] pass the buck down the vector's
+  ;; The [[emmy.dual/IPerturbed]] functions pass the buck down the vector's
   ;; elements.
   d/IPerturbed
   (replace-tag [v old new] (mapv #(d/replace-tag % old new) v))

--- a/src/emmy/collection.cljc
+++ b/src/emmy/collection.cljc
@@ -53,12 +53,12 @@
   f/IArity
   (arity [_] [:between 1 2])
 
-  ;; Vectors are functors, so they can be perturbed if any of their elements are
-  ;; perturbed. [[d/replace-tag]] and [[d/extract-tangent]] pass the buck down
-  ;; the vector's elements.
+  ;; [[d/replace-tag]] and [[d/extract-tangent]] pass the buck down the vector's
+  ;; elements.
   d/IPerturbed
   (replace-tag [v old new] (mapv #(d/replace-tag % old new) v))
-  (extract-tangent [v tag mode] (mapv #(d/extract-tangent % tag mode) v)))
+  (extract-tangent [v tag mode] (mapv #(d/extract-tangent % tag mode) v))
+  (extract-id [v id] (mapv #(d/extract-id % id) v)))
 
 ;; ## Sequences
 ;;
@@ -84,7 +84,10 @@
 
     d/IPerturbed
     (replace-tag [xs old new] (map #(d/replace-tag % old new) xs))
-    (extract-tangent [xs tag mode] (map #(d/extract-tangent % tag mode) xs))))
+    (extract-tangent [xs tag mode]
+      (map #(d/extract-tangent % tag mode) xs))
+    (extract-id [xs id]
+      (map #(d/extract-id % id) xs))))
 
 ;; ## Maps
 ;;
@@ -183,7 +186,15 @@
             ;; Do NOT attempt to recurse into the values if this map is being used as a
             ;; simple representation for some other type, like a manifold point.
             (u/unsupported (str "`extract-tangent` not supported for type " t "."))
-            (u/map-vals #(d/extract-tangent % tag mode) m)))})
+            (u/map-vals #(d/extract-tangent % tag mode) m)))
+
+        :extract-id
+        (fn [m id]
+          (if-let [t (:type m)]
+            ;; Do NOT attempt to recurse into the values if this map is being used as a
+            ;; simple representation for some other type, like a manifold point.
+            (u/unsupported (str "`extract-id` not supported for type " t "."))
+            (u/map-vals #(d/extract-id % id) m)))})
 
      :cljs
      (extend-type klass
@@ -202,7 +213,13 @@
            ;; Do NOT attempt to recurse into the values if this map is being used as a
            ;; simple representation for some other type, like a manifold point.
            (u/unsupported (str "`extract-tangent` not supported for type " t "."))
-           (u/map-vals #(d/extract-tangent % tag mode) m))))))
+           (u/map-vals #(d/extract-tangent % tag mode) m)))
+       (extract-id [m id]
+         (if-let [t (:type m)]
+           ;; Do NOT attempt to recurse into the values if this map is being used as a
+           ;; simple representation for some other type, like a manifold point.
+           (u/unsupported (str "`extract-id` not supported for type " t "."))
+           (u/map-vals #(d/extract-id % id) m))))))
 
 ;; ## Sets
 ;;

--- a/src/emmy/function.cljc
+++ b/src/emmy/function.cljc
@@ -150,7 +150,7 @@
         (g/one-like (apply f args)))
       (with-arity (arity f) {:from :one-like})))
 
-(def I
+(def ^:const I
   "Identity function. Returns its argument."
   identity)
 

--- a/src/emmy/generic.cljc
+++ b/src/emmy/generic.cljc
@@ -1074,7 +1074,7 @@ defaults to `ln((1 + sqrt(1+x^2)) / x)`."
 
 ;; ## More advanced generic operations
 
-(def ^:no-doc ^:const derivative-symbol 'D)
+(def ^:no-doc derivative-symbol 'D)
 
 (defgeneric partial-derivative 2)
 (defgeneric Lie-derivative 1)

--- a/src/emmy/generic.cljc
+++ b/src/emmy/generic.cljc
@@ -1074,7 +1074,7 @@ defaults to `ln((1 + sqrt(1+x^2)) / x)`."
 
 ;; ## More advanced generic operations
 
-(def ^:no-doc derivative-symbol 'D)
+(def ^:no-doc ^:const derivative-symbol 'D)
 
 (defgeneric partial-derivative 2)
 (defgeneric Lie-derivative 1)

--- a/src/emmy/matrix.cljc
+++ b/src/emmy/matrix.cljc
@@ -37,6 +37,7 @@
   d/IPerturbed
   (replace-tag [M old new] (fmap #(d/replace-tag % old new) M))
   (extract-tangent [M tag mode] (fmap #(d/extract-tangent % tag mode) M))
+  (extract-id [M id] (fmap #(d/extract-id % id) M))
 
   f/IArity
   (arity [_] (transduce (map f/seq-arity) f/combine-arities v))

--- a/src/emmy/operator.cljc
+++ b/src/emmy/operator.cljc
@@ -37,6 +37,8 @@
     (Operator. (d/replace-tag o old new) arity name context m))
   (extract-tangent [_ tag mode]
     (Operator. (d/extract-tangent o tag mode) arity name context m))
+  (extract-id [_ id]
+    (Operator. (d/extract-id o id) arity name context m))
 
   #?@(:clj
       [ILookup

--- a/src/emmy/polynomial.cljc
+++ b/src/emmy/polynomial.cljc
@@ -131,6 +131,9 @@
   (extract-tangent [this tag mode]
     (map-coefficients #(sd/extract-tangent % tag mode) this))
 
+  (extract-id [this id]
+    (map-coefficients #(sd/extract-id % id) this))
+
   v/IKind
   (kind [_] ::polynomial)
 

--- a/src/emmy/quaternion.cljc
+++ b/src/emmy/quaternion.cljc
@@ -559,26 +559,26 @@
 
 ;; ## Constructors
 
-(def ZERO
+(def ^:const ZERO
   "The zero quaternion. All coefficients are equal to 0."
   (->Quaternion 0 0 0 0 nil))
 
-(def ONE
+(def ^:const ONE
   "The identity quaternion. The real coefficient is equal to 1, and all
   coefficients are equal to 0."
   (->Quaternion 1 0 0 0 nil))
 
-(def I
+(def ^:const I
   "Unit quaternion with `i` coefficient equal to 1, all other coefficients equal
   to 0."
   (->Quaternion 0 1 0 0 nil))
 
-(def J
+(def ^:const J
   "Unit quaternion with `j` coefficient equal to 1, all other coefficients equal
   to 0."
   (->Quaternion 0 0 1 0 nil))
 
-(def K
+(def ^:const K
   "Unit quaternion with `k` coefficient equal to 1, all other coefficients equal
   to 0."
   (->Quaternion 0 0 0 1 nil))
@@ -1323,7 +1323,7 @@
 
 ;; ### Real 4x4 matrices
 
-(def ONE-matrix
+(def ^:const ONE-matrix
   "4x4 matrix representation of the quaternion [[ONE]]."
   (m/by-rows
    [1 0 0 0]
@@ -1331,7 +1331,7 @@
    [0 0 1 0]
    [0 0 0 1]))
 
-(def I-matrix
+(def ^:const I-matrix
   "4x4 matrix representation of the quaternion [[I]]."
   (m/by-rows
    [0 1 0 0]
@@ -1339,7 +1339,7 @@
    [0 0 0 -1]
    [0 0 1 0]))
 
-(def J-matrix
+(def ^:const J-matrix
   "4x4 matrix representation of the quaternion [[J]]."
   (m/by-rows
    [0 0 1 0]
@@ -1347,7 +1347,7 @@
    [-1 0 0 0]
    [0 -1 0 0]))
 
-(def K-matrix
+(def ^:const K-matrix
   "4x4 matrix representation of the quaternion [[K]]."
   (m/by-rows
    [0 0 0 1]
@@ -1372,25 +1372,25 @@
 
 ;; ### Tensor Representations of Quaternions
 
-(def ONE-tensor
+(def ^:const ONE-tensor
   "4x4 down-up tensor representation of the quaternion [[ONE]]."
   (m/->structure ONE-matrix))
 
-(def I-tensor
+(def ^:const I-tensor
   "4x4 down-up tensor representation of the quaternion [[I]]."
   (m/->structure I-matrix))
 
-(def J-tensor
+(def ^:const J-tensor
   "4x4 down-up tensor representation of the quaternion [[J]]."
   (m/->structure J-matrix))
 
-(def K-tensor
+(def ^:const K-tensor
   "4x4 down-up tensor representation of the quaternion [[K]]."
   (m/->structure K-matrix))
 
 ;; ### 3x3 Rotation Matrix Representations
 
-(def ^:private quarter (g// 1 4))
+(def ^:private ^:const quarter (g// 1 4))
 
 (defn from-rotation-matrix
   "Given an orthogonal 3x3 matrix M representing a rotation in 3-space, returns

--- a/src/emmy/quaternion.cljc
+++ b/src/emmy/quaternion.cljc
@@ -126,6 +126,14 @@
      (d/extract-tangent k tag mode)
      m))
 
+  (extract-id [_ id]
+    (Quaternion.
+     (d/extract-id r id)
+     (d/extract-id i id)
+     (d/extract-id j id)
+     (d/extract-id k id)
+     m))
+
   v/IKind
   (kind [_] ::quaternion)
 
@@ -551,26 +559,26 @@
 
 ;; ## Constructors
 
-(def ^:const ZERO
+(def ZERO
   "The zero quaternion. All coefficients are equal to 0."
   (->Quaternion 0 0 0 0 nil))
 
-(def ^:const ONE
+(def ONE
   "The identity quaternion. The real coefficient is equal to 1, and all
   coefficients are equal to 0."
   (->Quaternion 1 0 0 0 nil))
 
-(def ^:const I
+(def I
   "Unit quaternion with `i` coefficient equal to 1, all other coefficients equal
   to 0."
   (->Quaternion 0 1 0 0 nil))
 
-(def ^:const J
+(def J
   "Unit quaternion with `j` coefficient equal to 1, all other coefficients equal
   to 0."
   (->Quaternion 0 0 1 0 nil))
 
-(def ^:const K
+(def K
   "Unit quaternion with `k` coefficient equal to 1, all other coefficients equal
   to 0."
   (->Quaternion 0 0 0 1 nil))
@@ -1382,7 +1390,7 @@
 
 ;; ### 3x3 Rotation Matrix Representations
 
-(def ^:private ^:const quarter (g// 1 4))
+(def ^:private quarter (g// 1 4))
 
 (defn from-rotation-matrix
   "Given an orthogonal 3x3 matrix M representing a rotation in 3-space, returns

--- a/src/emmy/sci.cljc
+++ b/src/emmy/sci.cljc
@@ -12,8 +12,10 @@
   "SCI namespace map. Consumers wishing to use a more
   minimal SCI environment should select their desired namespaces from this map."
   {'emmy.algebra.fold                   (copy-ns emmy.algebra.fold (sci/create-ns 'emmy.algebra.fold))
+   'emmy.autodiff                        (copy-ns emmy.complex (sci/create-ns 'emmy.autodiff))
+
    'emmy.complex                        (copy-ns emmy.complex (sci/create-ns 'emmy.complex))
-   'emmy.dual                   (copy-ns emmy.dual (sci/create-ns 'emmy.dual))
+   'emmy.dual                           (copy-ns emmy.dual (sci/create-ns 'emmy.dual))
    'emmy.env                            (copy-ns emmy.env (sci/create-ns 'emmy.env))
    'emmy.expression                     (copy-ns emmy.expression (sci/create-ns 'emmy.expression))
    'emmy.function                       (copy-ns emmy.function (sci/create-ns 'emmy.function))
@@ -39,6 +41,8 @@
    'emmy.simplify                       (copy-ns emmy.simplify (sci/create-ns 'emmy.simplify))
    'emmy.simplify.rules                 (copy-ns emmy.simplify.rules (sci/create-ns 'emmy.simplify.rules))
    'emmy.structure                      (copy-ns emmy.structure (sci/create-ns 'emmy.structure))
+   'emmy.tape                           (copy-ns emmy.structure (sci/create-ns 'emmy.tape))
+
    'emmy.util                           (copy-ns emmy.util (sci/create-ns 'emmy.util))
    'emmy.value                          (copy-ns emmy.value (sci/create-ns 'emmy.value))
    'emmy.abstract.function              (copy-ns emmy.abstract.function (sci/create-ns 'emmy.abstract.function))

--- a/src/emmy/series.cljc
+++ b/src/emmy/series.cljc
@@ -41,6 +41,7 @@
   d/IPerturbed
   (replace-tag [s old new] (fmap #(d/replace-tag % old new) s))
   (extract-tangent [s tag mode] (fmap #(d/extract-tangent % tag mode) s))
+  (extract-id [s id] (fmap #(d/extract-id % id) s))
 
   v/IKind
   (kind [_] ::series)
@@ -197,6 +198,7 @@
   d/IPerturbed
   (replace-tag [s old new] (fmap #(d/replace-tag % old new) s))
   (extract-tangent [s tag mode] (fmap #(d/extract-tangent % tag mode) s))
+  (extract-id [s id] (fmap #(d/extract-id % id) s))
 
   v/IKind
   (kind [_] ::power-series)

--- a/src/emmy/structure.cljc
+++ b/src/emmy/structure.cljc
@@ -84,6 +84,7 @@
   d/IPerturbed
   (replace-tag [s old new] (mapr #(d/replace-tag % old new) s))
   (extract-tangent [s tag mode] (mapr #(d/extract-tangent % tag mode) s))
+  (extract-id [s id] (mapr #(d/extract-id % id) s))
 
   #?@(:clj
       [Object

--- a/src/emmy/tape.cljc
+++ b/src/emmy/tape.cljc
@@ -132,7 +132,7 @@
   ;; If called with [[emmy.dual/FORWARD-MODE]], a [[TapeCell]] should be treated
   ;; like a scalar, with a 0-valued tangent component.
   ;;
-  ;; Else,
+  ;; Else, only respond with [[reverse-phase]] if the tags match.
   (extract-tangent [this t mode]
     (cond (= mode d/FORWARD-MODE) 0
           (= t tag)               (reverse-phase this)
@@ -411,7 +411,8 @@
 ;; called a "sensitivity" while it's being accumulated. For functions that
 ;; return, say, a map of key => perturbed value, we need to run the reverse
 ;; phase for every value; rather than store a new map at each slot, we create a
-;; new [[Completed]] type to distinguish nested maps from sensitivity maps.
+;; new [[emmy.dual/Completed]] type to distinguish nested maps from sensitivity
+;; maps.
 
 (defn process [sensitivities tape]
   ;; Since we're processing in topological sort order, when we
@@ -433,8 +434,8 @@
 
 (defn ^:no-doc reverse-phase
   "Accepts a [[TapeCell]] `root` representing the final value, or output, of a
-  reverse-mode derivative computation, and returns a [[Completed]] instance
-  wrapping a map of
+  reverse-mode derivative computation, and returns an [[emmy.dual/Completed]]
+  instance wrapping a map of
 
   - each intermediate value seen in the computation to
   - the partial derivative of the output with respect to that value."
@@ -447,7 +448,7 @@
 ;; [[reverse-phase]] above operates on a single [[TapeCell]]. For structured
 ;; outputs, we need to walk the output until we hit a [[TapeCell]] instance and
 ;; call [[reverse-phase]] for each. This will result in an output-shaped
-;; structure of [[Completed]] instances.
+;; structure of [[emmy.dual/Completed]] instances.
 ;;
 ;; Unfortunately we require two passes over the output structure. The first one
 ;; calls [[reverse-phase]] via [[emmy.dual/extract-tangent]] to generate the
@@ -462,7 +463,7 @@
   "Given
 
   - a perturbed input, either a [[TapeCell]] or structure of [[TapeCell]]s
-  - an `output` [[Completed]] instance or structure of completed instances
+  - an `output` [[emmy.dual/Completed]] instance or structure of completed instances
   - the `tag` for the current run of differentiation
 
   Returns a value with the same shape as `input`, but with each [[TapeCell]]

--- a/src/emmy/tape.cljc
+++ b/src/emmy/tape.cljc
@@ -3,17 +3,12 @@
 (ns emmy.tape
   "This namespace contains an implementation of [[TapeCell]], a type that forms
   the basis for the reverse-mode automatic differentiation implementation in
-  Emmy.
-
-  NOTE that this type currently can't handle any interaction with forward-mode
-  AD! Don't nest [[gradient]] calls inside [[emmy.env/D]] calls."
+  Emmy."
   (:refer-clojure :exclude [compare zero?])
   (:require #?(:clj [clojure.pprint :as pprint])
             [emmy.dual :as d]
             [emmy.function :as f]
             [emmy.generic :as g]
-            [emmy.matrix :as matrix]
-            [emmy.operator :as o]
             [emmy.structure :as s]
             [emmy.util :as u]
             [emmy.value :as v]))
@@ -26,9 +21,9 @@
 ;;
 ;; This namespace develops an implementation of "reverse-mode" automatic
 ;; differentation, in contrast with the forward mode AD implementation
-;; in [[emmy.dual]]. These two are closely related, and the
-;; implementations could merge once I get around to reading and
-;; implementing [the YOLO paper](https://arxiv.org/abs/2204.10923).
+;; in [[emmy.dual]]. These two are closely related, and the implementations
+;; could merge once I get around to reading and implementing [the YOLO
+;; paper](https://arxiv.org/abs/2204.10923).
 ;;
 ;; The core idea of forward-mode AD is that we can use the chain rule to
 ;; mechanically build up a partial derivative by wrapping one of the dependent
@@ -124,8 +119,7 @@
 
 ;; Here's the [[TapeCell]] type with the fields described above.
 
-(declare compare)
-
+(declare compare reverse-phase)
 
 (deftype TapeCell [tag id primal in->partial]
   v/IKind
@@ -140,7 +134,12 @@
   ;; This implementation is called if a tape ever makes it out of
   ;; forward-mode-differentiated function. If this happens, a [[TapeCell]]
   ;; should be treated like a scalar, with a 0-valued tangent component.
-  (extract-tangent [_ _ _] 0)
+  (extract-tangent [this t mode]
+    (cond (= mode d/FORWARD-MODE) 0
+          (= t tag)               (reverse-phase this)
+          :else                   d/REVERSE-EMPTY))
+
+  (extract-id [_ _] 0)
 
   ;; A [[TapeCell]] has to respond `false` to all [[emmy.value/numerical?]]
   ;; inquiries; if we didn't do this, then [[emmy.generic/*]] and friends would
@@ -157,9 +156,9 @@
   #?(:cljs (valueOf [_] (.valueOf primal)))
   (toString [_]
     (str "#emmy.tape.TapeCell"
-         {:tag tag
-          :id id
-          :primal primal
+         {:tag         tag
+          :id          id
+          :primal      primal
           :in->partial in->partial}))
 
   #?@(:clj
@@ -414,21 +413,6 @@
 ;; return, say, a map of key => perturbed value, we need to run the reverse
 ;; phase for every value; rather than store a new map at each slot, we create a
 ;; new [[Completed]] type to distinguish nested maps from sensitivity maps.
-;;
-(defrecord Completed [v->partial]
-  d/IPerturbed
-  ;; NOTE that it's a problem that `replace-tag` is called on [[Completed]]
-  ;; instances now. In a future refactor I want `get` calls out of
-  ;; a [[Completed]] map to occur before tag replacement needs to happen.
-  (replace-tag [_ old new]
-    (Completed.
-     (u/map-vals #(d/replace-tag % old new) v->partial)))
-
-  ;; These should be called; it would be that a [[Completed]] instance has
-  ;; escaped from a derivative call. These are meant to be an internal
-  ;; implementation detail only.
-  (extract-tangent [_ _ _]
-    (assert "Impossible!")))
 
 (defn process [sensitivities tape]
   ;; Since we're processing in topological sort order, when we
@@ -458,81 +442,16 @@
   [root]
   (let [nodes         (topological-sort root)
         sensitivities {(tape-id root) 1}]
-    (->Completed
+    (d/->Completed
      (reduce process sensitivities nodes))))
 
 ;; [[reverse-phase]] above operates on a single [[TapeCell]]. For structured
 ;; outputs, we need to walk the output until we hit a [[TapeCell]] instance and
 ;; call [[reverse-phase]] for each. This will result in an output-shaped
 ;; structure of [[Completed]] instances.
+
+;; TODO explain ->partials going away...
 ;;
-;; TODO [[->partials]] really should depend on `fmap`, as should so many other
-;; things in the library. Without this we can't generically support output
-;; values like maps or quaternions. [[emmy.dual/extract-tangent]] does
-;; this for forward-mode, I believe.
-
-(declare ->partials)
-
-(defn- ->partials-fn
-  "Returns a new function that composes a 'tag extraction' step with `f`. The
-  returned fn will
-
-  - call the underlying `f`, producing `result`
-  - return `(->partials result tag)`
-
-  If called within the scope of a function waiting for the same `tag`, the
-  returned function will remap any instance of `tag` that appears in any
-  differential argument passed to it to a private `fresh` tag, to prevent
-  internal perturbation confusion. Any perturbations in the final result tagged
-  with `fresh` will be remapped in the final result back to `tag`. If called
-  _outside_ of a function waiting for `tag` no tag remapping will occur."
-  [f tag]
-  (-> (fn [& args]
-        (if (d/tag-active? tag)
-          (let [fresh (d/fresh-tag)]
-            (-> (d/with-active-tag tag f (map #(d/replace-tag % tag fresh) args))
-                (->partials tag)
-                (d/replace-tag fresh tag)))
-          (-> (d/with-active-tag tag f args)
-              (->partials tag))))
-      (f/with-arity (f/arity f))))
-
-(defn ^:no-doc ->partials
-  "Given some possibly-structured `output` of the forward pass and a `tag`,
-  returns either
-
-  - a [[Completed]] instance wrapping a map of intermediate value => partial
-    derivative, or
-  - the same structure as `output` will leaves replaced with [[Completed]]
-    instances
-
-  Pass the result to [[extract]] along with the ID of some input node to obtain
-  the partial derivative with respect to that ID."
-  [output tag]
-  (cond (and (tape? output) (= tag (tape-tag output)))
-        (reverse-phase output)
-
-        (vector? output)
-        (mapv #(->partials % tag) output)
-
-        (s/structure? output)
-        (s/mapr #(->partials % tag) output)
-
-        (f/function? output)
-        (->partials-fn output tag)
-
-        (o/operator? output)
-        (o/->Operator (->partials-fn (o/procedure output) tag)
-                      (o/arity output)
-                      (o/name output)
-                      (o/context output)
-                      (meta output))
-
-        (v/scalar? output)
-        (->Completed {})
-
-        :else (u/unsupported "Output not handled yet!")))
-
 ;; Unfortunately we require two passes over the output structure. The first one
 ;; generates the maps of partials, and the second pass extracts the partial we
 ;; care about.
@@ -541,43 +460,9 @@
 ;; combine these. But for multiple inputs, [[extract]] will be called multiple
 ;; times, one for each input.
 
-(defn ^:no-doc extract
-  "Given
-
-  - an `output` [[Completed]] instance or structure of completed instances
-  - the `id` of some variable
-
-  returns a value of the same shape as `output` with all [[Completed]] instances
-  replaced by the partial derivative associated with `id`."
-  [output id]
-  (cond (instance? Completed output)
-        (get (:v->partial output) id 0)
-
-        (vector? output)
-        (mapv #(extract % id) output)
-
-        (s/structure? output)
-        (s/mapr #(extract % id) output)
-
-        (f/function? output)
-        (comp #(extract % id) output)
-
-        (o/operator? output)
-        (o/->Operator (extract (o/procedure output) id)
-                      (o/arity output)
-                      (o/name output)
-                      (o/context output)
-                      (meta output))
-
-        :else 0))
-
 ;; TODO note that [[interpret]] and [[tapify]] both need to become generic on
-;; input-walking, and [[extract]] and [[->partials]] need to be generic on
-;; output-walking.
-;;
-;; I am sure we are going to need to glom on to the [[replace-tag]] machinery as
-;; well. [[emmy.dual/extract-tangent]] is similar to what we want. Maybe
-;; we can share?
+;; input-walking, and [[extract]] and [[emmy.dual/extract-tangent]] need to be
+;; generic on output-walking.
 
 (defn ^:no-doc interpret
   "Given
@@ -591,7 +476,7 @@
   computation at that leaf."
   [input output tag]
   (cond (and (tape? input) (= tag (tape-tag input)))
-        (extract output (tape-id input))
+        (d/extract-id output (tape-id input))
 
         (s/structure? input)
         (s/opposite input (mapv #(interpret % output tag) input))
@@ -625,30 +510,21 @@
   function calls."
   ([f] (gradient f []))
   ([f selectors]
-   (fn
-     ([] 0)
-     ([x]
-      (when (and (seq selectors) (not (s/structure? x)))
-        (u/illegal
-         (str "Selectors " selectors
-              " not allowed for non-structural input " x)))
+   (fn [x]
+     (when (and (seq selectors) (not (s/structure? x)))
+       (u/illegal
+        (str "Selectors " selectors
+             " not allowed for non-structural input " x)))
 
-      (let [tag       (d/fresh-tag)
-            inputs    (if (empty? selectors)
-                        (tapify x tag)
-                        (update-in x selectors tapify tag))
-            output    (d/with-active-tag tag f [inputs])
-            completed (->partials output tag)]
-        (if (empty? selectors)
-          (interpret inputs completed tag)
-          (interpret (get-in inputs selectors) completed tag))))
-     ([x & more]
-      ((gradient (fn [args]
-                   (apply f args))
-                 selectors)
-       (matrix/seq-> (cons x more)))))))
-
-;; ## TapeCell Generics
+     (let [tag       (d/fresh-tag)
+           inputs    (if (empty? selectors)
+                       (tapify x tag)
+                       (update-in x selectors tapify tag))
+           output    (d/with-active-tag tag f [inputs])
+           completed (d/extract-tangent output tag d/REVERSE-MODE)]
+       (if (empty? selectors)
+         (interpret inputs completed tag)
+         (interpret (get-in inputs selectors) completed tag))))))
 
 (defmethod g/zero-like [::tape] [_] 0)
 (defmethod g/one-like [::tape] [_] 1)

--- a/test/emmy/calculus/derivative_test.cljc
+++ b/test/emmy/calculus/derivative_test.cljc
@@ -5,7 +5,7 @@
   (:require [clojure.test :refer [is deftest testing use-fixtures]]
             [emmy.abstract.function :as af]
             [emmy.abstract.number :refer [literal-number]]
-            [emmy.calculus.derivative :as d :refer [D partial]]
+            [emmy.calculus.derivative :as d]
             [emmy.complex :as c]
             [emmy.dual :as sd]
             [emmy.expression :as x]
@@ -47,7 +47,7 @@
                         call to Df the `tag` IS active.")
                     (g/cube x)))))))))
 
-(deftest basic-D-tests
+(defn basic-D-tests [D]
   (is (= 0 ((D (fn [] 100))))
       "D of no-arg returns zero")
 
@@ -113,7 +113,7 @@
         "the Jacobian of a permutation is the permutation matrix of that
         permutation")))
 
-(deftest derivative-return-tests
+(defn derivative-return-tests [D]
   (testing "Series, PowerSeries"
     (let [series-D ((D series/exp-series) 'x)]
       (is (series/series? series-D)
@@ -167,7 +167,7 @@
               (((D f) 'x) 'y)))
           "derivative pushes into the operator's fn.."))))
 
-(deftest partial-diff-test
+(defn partial-diff-test [D partial]
   (testing "partial derivative simplification rules"
     (let [f (af/literal-function 'f '(-> (UP Real Real) Real))]
       (is (= '(((* (expt (partial 0) 2) (partial 1)) f) (up x y))
@@ -218,7 +218,7 @@
       (is (= (s/down (s/up 'x 0) (s/up 0 'y))
              (((D F) 1 1) (s/up 'x 'y)))))))
 
-(defn- δ [η]
+(defn δ [D η]
   (fn [f]
     ;; Define g(ε) as in Eq. 1.22; then δ_η f[q] = Dg(0)
     (fn [q]
@@ -226,14 +226,14 @@
                 (f (+ q (* ε η))))]
         ((D g) 0)))))
 
-(deftest delta-eta-tests
+(defn delta-eta-tests [D]
   (af/with-literal-functions [η q f g]
     (let [I (fn [q] q)
           F (fn [q] (fn [t] (f (q t))))
           G (fn [q] (fn [t] (g (q t))))
           q+εη (+ q (* 'ε η))
           g (fn [ε] (+ q (* ε η)))
-          δη (δ η)
+          δη (δ D η)
           δηI (δη I)
           δηIq (δηI q)
           δηFq ((δη F) q)
@@ -265,7 +265,7 @@
         (is (= '(* (η t) ((D f) (q t)) ((D φ) (f (q t))))
                (simplify (((δη (φ F)) q) 't))))))))
 
-(deftest exponentiation-and-composition
+(defn exponentiation-and-composition [D]
   (let [ff (fn [x y z]
              (+ (* x x y)
                 (* y y z)
@@ -356,7 +356,7 @@
       (is (= 0 ((D (fn [_x] 0)) 'x)))
       (is (= 0 ((D (fn [& _xs] 0)) 'x))))))
 
-(deftest literal-function-tests
+(defn literal-function-tests [D partial]
   (af/with-literal-functions [f [g [0 0] 0]]
     (testing "R -> R"
       (is (= '((D f) x) (simplify ((D f) 'x))))
@@ -377,13 +377,13 @@
       (is (= 0 ((g/zero-like f) 'x)))
       (is (= 0 ((D (g/zero-like f)) 'x))))))
 
-(deftest complex-derivatives
+(defn complex-derivatives [D]
   (let [f (fn [z] (* c/I (sin (* c/I z))))]
     (is (= '(* -1 (cosh z))
            (simplify
             ((D f) 'z))))))
 
-(deftest operator-tests
+(defn operator-tests [D]
   (testing "operator multiplication by fn == "
     (is (= '(+ (* (expt t 3) (cos t))
                (* 3 (expt t 2) (sin t)))
@@ -394,7 +394,7 @@
          (simplify (((* sin D) g/cube) 't)))
       "fn * D == multiplies after D"))
 
-(deftest more-trig-tests
+(defn more-trig-tests [D]
   (testing "cotangent"
     (is (= '(/ (cos x) (sin x))
            (simplify (cot 'x))))
@@ -442,7 +442,7 @@
             "This style uses function arithmetic and applies 'x at the
             end.")))))
 
-(deftest alexgian-examples
+(defn alexgian-examples [D partial]
   (testing "space"
     (let [g (af/literal-function 'g [0 0] 0)
           h (af/literal-function 'h [0 0] 0)]
@@ -518,7 +518,7 @@
       (is (ish? expected ((D f100e) 6)))
       (is (ish? expected ((D f100ea) 6))))))
 
-(deftest deep-partials
+(defn deep-partials [partial]
   (let [f (fn [x y] (+ (g/square x) (g/square (g/square y))))]
     (is (= '((* 2 x)
              (* 2 y)
@@ -531,7 +531,7 @@
     (is (thrown? #?(:clj IllegalArgumentException :cljs js/Error)
                  (((partial 0 1) f) 'x 'y)))))
 
-(deftest derivative-as-operator
+(defn derivative-as-operator [D]
   (let [f (af/literal-function 'f [0 0] 0)
         g (af/literal-function 'g (s/up 0 0) 0)
         dX (s/up 'dx 'dy)]
@@ -561,7 +561,7 @@
                (* (expt dy 2) (((expt (partial 1) 2) f) x y)))
            (simplify (* dX (((g/expt D 2) f) 'x 'y) dX))))))
 
-(deftest moved-from-structure-and-matrix
+(defn moved-from-structure-and-matrix [D]
   (testing "as-matrix, D-as-matrix"
     (let [S (s/up 't (s/up 'x 'y) (s/down 'p_x 'p_y))
           present (fn [expr]
@@ -648,7 +648,7 @@
              (simplify
               (matrix/s->m vs (((g/expt D 2) L1) vs) vs)))))))
 
-(deftest moved-from-matrix
+(defn moved-from-matrix [D]
   (testing "s->m->s"
     (let [as-matrix (fn [F]
                       (fn [s]
@@ -691,7 +691,7 @@
              (simplify
               ((as-matrix (D C-general)) s)))))))
 
-(deftest taylor-moved-from-series
+(defn taylor-moved-from-series [D]
   (let [simp4 (fn [x] (simplify (take 4 x)))
         V (series/series g/sin g/cos g/tan)]
 
@@ -703,8 +703,8 @@
 
     (testing "f -> Series"
       (let [F (fn [k] (series/series
-                       (fn [t] (g/* k t))
-                       (fn [t] (g/* k k t))))]
+                      (fn [t] (g/* k t))
+                      (fn [t] (g/* k k t))))]
         (is (= '((* q z) (* (expt q 2) z) 0 0) (simp4 ((F 'q) 'z))))
         (is (= '(z (* 2 q z) 0 0) (simp4 (((D F) 'q) 'z)))))))
 
@@ -727,7 +727,7 @@
                     (fn [x] (g/sqrt (+ (g/one-like x) x)))
                     0) 'dx))))))
 
-(deftest derivative-of-matrix
+(defn derivative-of-matrix [D]
   (let [M (matrix/by-rows [(af/literal-function 'f) (af/literal-function 'g)]
                           [(af/literal-function 'h) (af/literal-function 'k)])]
     (is (= '(matrix-by-rows
@@ -764,7 +764,7 @@
            (simplify
             ((D (* (g/transpose M) M)) 't))))))
 
-(deftest derivatives-as-values
+(defn derivatives-as-values [D]
   (let [cs0 (fn [x] (sin (cos x)))
         cs1 (f/compose sin cos)
         cs2 (comp sin cos)
@@ -790,7 +790,7 @@
 ;; Tests from the refman that came about while implementing various derivative
 ;; and operator functions.
 
-(deftest refman-tests
+(defn refman-tests [D]
   (testing "o/expn expansion of `D`"
     (let [f     (af/literal-function 'f)
           ->seq (comp simplify #(take 10 %))]
@@ -851,7 +851,7 @@
             (is (ish? (Math/cos 1) (via-series 1)))
             (is (ish? (Math/cos 0.6) (via-series 0.6)))))))))
 
-(deftest higher-order-fn-tests
+(defn higher-order-fn-tests [D]
   (letfn [(f [x]
             (fn [y z]
               (g/* x y z)))]
@@ -873,7 +873,7 @@
 #?(:clj
    ;; NOTE these are disabled for cljs because they force themselves into ratio
    ;; arithmetic!
-   (deftest newton-raphson-sqrt
+   (defn newton-raphson-sqrt [D]
      (testing "autodiff works through arbitrary optimization loops!"
        (with-comparator (v/within 1e-8)
          (letfn [(nr-sqrt [x]
@@ -898,7 +898,7 @@
              (is (ish? (/ -1 108) (((g/square D) nr-sqrt) 9)))
              (is (ish? (/ -1 256) (((g/square D) nr-sqrt) 16)))))))))
 
-(deftest amazing-bug
+(defn amazing-bug [D]
   (testing "alexey's amazing bug"
     (let [shift (fn [offset]
                   (fn [g]
@@ -1210,7 +1210,7 @@
                  (wrapped-d-hat
                   (wrapped-d-hat (wrap exp)))) 1)))))))
 
-(deftest sams-amazing-bug
+(defn sams-amazing-bug [D]
   ;; This test shows a potential pitfall that might bite you if you're not
   ;; careful about tracking the scope introduced by each call to [[d/D]]. This
   ;; gets tricky with derivatives of higher order functions.
@@ -1272,8 +1272,8 @@
             mixed partial instead."))
 
       ;; You see this because the `list` continuation triggers
-      ;; an `(extract-tangent ,,, tag)` call on each component of the `list`
-      ;; separately, so the returned `f1`and `f2` are both composed with
+      ;; an `(extract-tangent ,,, tag mode)` call on each component of the
+      ;; `list` separately, so the returned `f1`and `f2` are both composed with
       ;; `extract-tangent` calls for the tangent associated with the scope
       ;; introduced by `(D f)`.
       ;;
@@ -1282,7 +1282,7 @@
       ;; together!
       )))
 
-(deftest dvl-bug-examples
+(defn dvl-bug-examples [D]
   ;; These tests and comments all come from Alexey Radul's
   ;; https://github.com/axch/dysvunctional-language. Thanks, Alexey!
 
@@ -1320,7 +1320,7 @@
                  (fn [g]
                    (fn [z] (g (+ x z)))))))]
       (is (ish? ((fn [y] (+ (* 3 (cos (* 3 y)))
-                            (* y (cos (* 3 y)))))
+                           (* y (cos (* 3 y)))))
                  (+ 3 Math/PI))
                 (((D f) 3)
                  (fn [g-hat f-hat]
@@ -1342,10 +1342,9 @@
     ;; space.
     ;;
     ;; Doing work inside a continuation means you're actually working
-    ;; with [[emmy.dual/Dual]] instances whose tangents can
-    ;; interact. Once you break out of the continuation, as in "bug two", the
-    ;; two components separately drop their tangents, so they can't talk
-    ;; anymore.
+    ;; with [[emmy.dual/Dual]] instances whose tangents can interact. Once you
+    ;; break out of the continuation, as in "bug two", the two components
+    ;; separately drop their tangents, so they can't talk anymore.
     ;;
     ;; The "linear" comment matters because if you only combine the dropped-down
     ;; pieces linearly, then their tangents wouldn't have interacted anyway, so
@@ -1390,7 +1389,7 @@
       (is (= (* 2 (sin 1) (cos 1))
              ((D (fn [x] (* (sin x) (sin x)))) 1))))))
 
-(deftest confusion-tests
+(defn confusion-tests [D]
   ;; More tests from dvl stressing perturbation confusion.
   (testing "don't confuse perturbations, from dvl"
     (letfn [(one [x]
@@ -1494,7 +1493,7 @@
                   (take 3)
                   (simplify)))))))
 
-(deftest symbolic-taylor-series-tests
+(defn symbolic-taylor-series-tests [D]
   (let [xs (d/symbolic-taylor-series exp 0)]
     (is (series/power-series? xs)
         "we have a proper power series!")
@@ -1585,14 +1584,13 @@
       differential instances.")
 
   (is (v/= [0 1 0 0]
-           ((tape/gradient
-             (fn [y]
-               (into [] (take 4 (d/symbolic-taylor-series
-                                 (fn [x] (g/* x y))
-                                 0)))))
-            'a))
-      "works with gradient too! TODO once gradients support series outputs,
-      massage this into better shape...")
+           (take 4 ((tape/gradient
+                     (fn [y]
+                       (d/symbolic-taylor-series
+                        (fn [x] (g/* x y))
+                        0)))
+                    'a)))
+      "works with gradient too!")
 
   (testing "compare, one stays symbolic:"
     (letfn [(f [[a b]]
@@ -1617,3 +1615,33 @@
                   (take 2)))
           "symbolic-taylor-series keeps the arguments symbolic, even when they
           are numbers."))))
+
+(defn all-tests [D partial]
+  (basic-D-tests D)
+  (derivative-return-tests D)
+  (partial-diff-test D partial)
+  (delta-eta-tests D)
+  (exponentiation-and-composition D)
+  (literal-function-tests D partial)
+  (complex-derivatives D)
+  (operator-tests D)
+  (more-trig-tests D)
+  (hermetic-simplify-fixture #(alexgian-examples D partial))
+  (deep-partials partial)
+  (derivative-as-operator D)
+  (moved-from-structure-and-matrix D)
+  (moved-from-matrix D)
+  (taylor-moved-from-series D)
+  (hermetic-simplify-fixture #(derivative-of-matrix D))
+  (hermetic-simplify-fixture #(derivatives-as-values D))
+  (refman-tests D)
+  (higher-order-fn-tests D)
+  #?(:clj (newton-raphson-sqrt D))
+  (amazing-bug D)
+  (sams-amazing-bug D)
+  (dvl-bug-examples D)
+  (confusion-tests D)
+  (symbolic-taylor-series-tests D))
+
+(deftest forward-mode-tests
+  (all-tests d/D d/partial))

--- a/test/emmy/collection_test.cljc
+++ b/test/emmy/collection_test.cljc
@@ -7,7 +7,6 @@
             [emmy.calculus.derivative :refer [D]]
             [emmy.collection :as collection]
             [emmy.complex :refer [complex I]]
-            [emmy.dual :as d]
             [emmy.function :as f]
             [emmy.generators :as sg]
             [emmy.generic :as g]

--- a/test/emmy/generators.cljc
+++ b/test/emmy/generators.cljc
@@ -280,7 +280,7 @@
   ([entry-gen]
    (gen/fmap ss/power-series* (gen/vector entry-gen))))
 
-;; ## Differential
+;; ## Dual Numbers
 
 (defn dual
   "Returns a generator that produces proper instances

--- a/test/emmy/polynomial_test.cljc
+++ b/test/emmy/polynomial_test.cljc
@@ -6,7 +6,6 @@
             [com.gfredericks.test.chuck.clojure-test :refer [checking]]
             [emmy.abstract.number :as an]
             [emmy.calculus.derivative :refer [D]]
-            [emmy.dual :as sd]
             [emmy.expression :as x :refer [variables-in expression-of]]
             [emmy.expression.analyze :as a]
             [emmy.function :as f]

--- a/test/emmy/series_test.cljc
+++ b/test/emmy/series_test.cljc
@@ -666,10 +666,10 @@
 
 (deftest cos-1-square-terms
   (testing "Generate terms for the power series expansion of $cos(z)-1$."
-  ;; (take 10 (g/- s/cos-series 1))
-  ;; => (0 0 -1/2 0 1/24 0 -1/720 0 1/40320 0)
-  ;; From this we can see that we may regard the expansion as a series in x^2, with a
-  ;; zero constant term.
+    ;; (take 10 (g/- s/cos-series 1))
+    ;; => (0 0 -1/2 0 1/24 0 -1/720 0 1/40320 0)
+    ;; From this we can see that we may regard the expansion as a series in x^2, with a
+    ;; zero constant term.
     (let [terms (->> (g/- s/cos-series 1)
                      (remove g/zero?)  ;; eliminate the useless zero coefficients of the odd powers of x
                      (map double)      ;; we don't want the rational arithmetic to survive

--- a/test/emmy/tape_test.cljc
+++ b/test/emmy/tape_test.cljc
@@ -4,8 +4,8 @@
   (:require #?(:clj [clojure.pprint :as pprint])
             [clojure.test :refer [is deftest testing use-fixtures]]
             [clojure.test.check.generators :as gen]
-            [emmy.autodiff :as ad]
             [com.gfredericks.test.chuck.clojure-test :refer [checking]]
+            [emmy.autodiff :as ad]
             [emmy.calculus.derivative :refer [D]]
             [emmy.dual :as d]
             [emmy.expression.analyze :as a]

--- a/test/emmy/tape_test.cljc
+++ b/test/emmy/tape_test.cljc
@@ -529,11 +529,11 @@
               (g/simplify
                ((t/gradient f) ['x 'y 'z])))))
 
-      (is (= (g/simplify
-              ((D f) ['x 'y 'z]))
-             (g/simplify
-              ((t/gradient f) ['x 'y 'z])))
-          "reverse-mode matches forward-mode.")
+      #_(is (= (g/simplify
+                ((D f) ['x 'y 'z]))
+               (g/simplify
+                ((t/gradient f) ['x 'y 'z])))
+            "reverse-mode matches forward-mode.")
 
       (is (= ((t/gradient f) ['x 'y 'z])
              (s/down
@@ -585,42 +585,4 @@
               ((D f) ['x 'y 'z]))
              (g/simplify
               ((t/gradient f) ['x 'y 'z])))
-          "reverse-mode matches forward-mode.")))
-
-  (testing "multiple input, vector output"
-    (let [f (fn [a b c d e f]
-              [(g/* (g/cos a) (g/cos b))
-               (g/* (g/cos c) (g/cos d))
-               (g/* (g/cos e) (g/cos f))])
-          expected (g/simplify
-                    ((D (D f)) 'a 'b 'c 'd 'e 'f))]
-      (is (= expected
-             (g/simplify
-              ((t/gradient (t/gradient f)) 'a 'b 'c 'd 'e 'f)))
-          "multivariable derivatives match (reverse-over-reverse)"))))
-
-(deftest mixed-mode-tests
-  (testing "nested reverse mode"
-    (let [f (fn [x]
-              (fn [y]
-                (g/* (g/square x) (g/square y))))]
-      (is (= ((D ((t/gradient f) 'x)) 'y)
-             ((t/gradient ((D f) 'x)) 'y)
-             ((t/gradient ((t/gradient f) 'x)) 'y))
-          "reverse-mode nests with forward-mode")))
-
-  (let [f (fn [a b c d e f]
-            [(g/* (g/cos a) (g/cos b))
-             (g/* (g/cos c) (g/cos d))
-             (g/* (g/cos e) (g/cos f))])
-        expected (g/simplify
-                  ((D (D f)) 'a 'b 'c 'd 'e 'f))]
-    (is (= expected
-           (g/simplify
-            ((D (t/gradient f)) 'a 'b 'c 'd 'e 'f)))
-        "forward-over-reverse")
-
-    (is (= expected
-           (g/simplify
-            ((t/gradient (D f)) 'a 'b 'c 'd 'e 'f)))
-        "reverse-over-forward")))
+          "reverse-mode matches forward-mode."))))

--- a/test/emmy/tape_test.cljc
+++ b/test/emmy/tape_test.cljc
@@ -529,11 +529,11 @@
               (g/simplify
                ((t/gradient f) ['x 'y 'z])))))
 
-      #_(is (= (g/simplify
-                ((D f) ['x 'y 'z]))
-               (g/simplify
-                ((t/gradient f) ['x 'y 'z])))
-            "reverse-mode matches forward-mode.")
+      (is (= (g/simplify
+              ((D f) ['x 'y 'z]))
+             (g/simplify
+              ((t/gradient f) ['x 'y 'z])))
+          "reverse-mode matches forward-mode.")
 
       (is (= ((t/gradient f) ['x 'y 'z])
              (s/down


### PR DESCRIPTION
- #183:

  - adds `emmy.{autodiff, tape}` to `emmy.sci`'s exported namespace set

  - adds `emmy.dual/extract-id` implementations for all supported output types
    (every type that already implements `emmy.dual/IPerturbed`)

  - moves `emmy.tape/Completed` to `emmy.dual/Completed`; it doesn't really make
    sense there, but this is the only current way to remove the circular
    dependency between `emmy.dual` and `emmy.tape`. (`tape` needs a `dual`
    import to gain `emmy.dual/IPerturbed`.)

  - simplifies the `emmy.tape/gradient` implementation down to only handle
    single real-or-structural arguments, just like `emmy.dual/derivative`. We'll
    share the "handle-multiple-input" implementation between the two in a
    follow-up PR

  - makes the tests in `emmy.calculus.derivative` generic on the derivative
    implementation, so we can run all tests in forward and reverse mode.