### PR TITLE
add forward, reverse-mode AD operators, enable tests for reverse-mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,23 @@
 
 ## [unreleased]
 
+- #185:
+
+  - adds a dynamic variable `emmy.calculus.derivative/*mode*` that allows the
+    user to switch between forward and reverse mode automatic differentiation
+
+  - adds a new `emmy.calculus.derivative/gradient` that acts like
+    `emmy.tape/gradient` but is capable of taking multiple variables
+
+  - adds new operators `emmy.calculus.derivative/{D-forward, D-reverse}` and
+    operator-returning-functions `emmy.calculus.derivative/{partial-forward,
+    partial-reverse}` that allow the user to explicitly invoke forward-mode or
+    reverse-mode automatic differentiation. `D` and `partial` still default to
+    forward-mode
+
+  - modifies `emmy.tape/gradient` to correctly error when passed invalid
+    selectors, just like `emmy.dual/derivative`.
+
 - #183:
 
   - adds `emmy.{autodiff, tape}` to `emmy.sci`'s exported namespace set

--- a/src/emmy/calculus/derivative.cljc
+++ b/src/emmy/calculus/derivative.cljc
@@ -143,7 +143,7 @@
               (str "Selectors " selectors
                    " not allowed for non-structural input " input)))))))
 
-(defn multi
+(defn- multi
   "Given
 
     - some higher-order function `op` that transforms a function of a single

--- a/test/emmy/calculus/derivative_test.cljc
+++ b/test/emmy/calculus/derivative_test.cljc
@@ -1616,9 +1616,6 @@
           "symbolic-taylor-series keeps the arguments symbolic, even when they
           are numbers."))))
 
-;; TODO enable when we add our gradient impl in the next PR.
-
-#_
 (deftest mixed-mode-tests
   (testing "multiple input, vector output"
     (let [f (fn [a b c d e f]
@@ -1686,3 +1683,7 @@
 
 (deftest forward-mode-tests
   (all-tests d/D d/partial))
+
+(deftest reverse-mode-tests
+  (all-tests d/D-reverse
+             d/partial-reverse))


### PR DESCRIPTION
  - adds a dynamic variable `emmy.calculus.derivative/*mode*` that allows the
    user to switch between forward and reverse mode automatic differentiation

  - adds a new `emmy.calculus.derivative/gradient` that acts like
    `emmy.tape/gradient` but is capable of taking multiple variables

  - adds new operators `emmy.calculus.derivative/{D-forward, D-reverse}` and
    operator-returning-functions `emmy.calculus.derivative/{partial-forward,
    partial-reverse}` that allow the user to explicitly invoke forward-mode or
    reverse-mode automatic differentiation. `D` and `partial` still default to
    forward-mode

  - modifies `emmy.tape/gradient` to correctly error when passed invalid
    selectors, just like `emmy.dual/derivative`.